### PR TITLE
Adding Support Jump v0.18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: julia
 
 os:
   - linux
-  - osx
+#  - osx
 
 julia:
   - 0.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: julia
 
 os:
   - linux
-#  - osx
+  - osx
 
 julia:
   - 0.5

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.5
 JSON 0.6.0
 MathProgBase 0.5.4
-JuMP 0.17 0.18-
+JuMP 0.17 0.19-
 Compat 0.17

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -4,5 +4,6 @@ Ipopt
 AmplNLWriter
 CoinOptServices
 Compat
-Logging
+Logging 0.2
 Pajarito
+


### PR DESCRIPTION
This addresses #5.  Note that v0.18 is only available in Julia v0.6.  Seems to be working, Mac builds are just slow on Travis at the moment.