### PR TITLE
FIX: calc_connected_components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # GasModels.jl Change Log
 
 ## Pending
-- bug fix for storage 
-- compressors are made optional components
 
+- bug fix for storage
+- compressors are made optional components
+- fixed bug in `calc_connected_components`
 
 ## v0.8
 

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -1626,7 +1626,7 @@ function calc_connected_components(data::Dict{String,<:Any}; edges = _gm_edge_ty
 
     active_junction = Dict(x for x in data["junction"] if x.second["status"] != 0)
     active_junction_ids =
-        Set{Int64}([junction["junction_i"] for (i, junction) in active_junction])
+        Set{Int64}([junction["id"] for (i, junction) in active_junction])
 
     neighbors = Dict(i => [] for i in active_junction_ids)
     for edge_type in edges

--- a/test/data.jl
+++ b/test/data.jl
@@ -93,69 +93,8 @@
         end
     end
 
-    #=
-    @testset "check data parser warnings / errors" begin
-        gas_file = "../test/data/warnings.m"
-
-        Memento.setlevel!(TESTLOG, "warn")
-
-        @test_warn(TESTLOG, "pmax 6.0e6 at junction 4 is > 5.861e6 Pa (850 PSI)", GasModels.parse_file(gas_file))
-        @test_warn(TESTLOG, "max power 100.0 MW > 20MW on compressor 1", GasModels.parse_file(gas_file))
-        @test_warn(TESTLOG, "max c-ratio 2.5 on compressor 1 is unrealistic", GasModels.parse_file(gas_file))
-        @test_warn(TESTLOG, "min c-ratio 0.5 on compressor 1 is unrealistic", GasModels.parse_file(gas_file))
-        @test_warn(TESTLOG, "baseP 1000000 is different than calculated baseP = 3.0e6", GasModels.parse_file(gas_file))
-        @test_warn(TESTLOG, "baseQ 7000.0 is different than calculated baseQ = 10033.444816053512", GasModels.parse_file(gas_file))
-        @test_warn(TESTLOG, "temperature of 259.0 K is unrealistic", GasModels.parse_file(gas_file))
-        @test_warn(TESTLOG, "gas specific gravity 0.4 is unrealistic", GasModels.parse_file(gas_file))
-        @test_warn(TESTLOG, "R / molar mass of 800.0 is unrealistic", GasModels.parse_file(gas_file))
-        @test_warn(TESTLOG, "sound speed of 299.0 m/s is unrealistic", GasModels.parse_file(gas_file))
-        @test_warn(TESTLOG, "compressibility_factor 0.6 is unrealistic", GasModels.parse_file(gas_file))
-
-        Memento.setlevel!(TESTLOG, "error")
-
-        data = GasModels.parse_file(gas_file)
-
-        data["junction"]["1"]["p_min"] = -1
-        @test_throws(TESTLOG, ErrorException, GasModels.correct_network_data!(data))
-        data["junction"]["1"]["p_min"] = 3.0
-
-        data["junction"]["1"]["p_max"] = -1
-        @test_throws(TESTLOG, ErrorException, GasModels.correct_network_data!(data))
-        data["junction"]["1"]["p_max"] = 6.0
-
-        data["pipe"]["1"]["diameter"] = -1
-        @test_throws(TESTLOG, ErrorException, GasModels.correct_network_data!(data))
-        data["pipe"]["1"]["diameter"] = 0.6
-
-        data["pipe"]["1"]["friction_factor"] = -1
-        @test_throws(TESTLOG, ErrorException, GasModels.correct_network_data!(data))
-        data["pipe"]["1"]["friction_factor"] = 0.01
-
-        data["compressor"]["1"]["c_ratio_max"] = -1
-        @test_throws(TESTLOG, ErrorException, GasModels.correct_network_data!(data))
-        data["compressor"]["1"]["c_ratio_max"] = 2.5
-
-        data["compressor"]["1"]["c_ratio_min"] = -1
-        @test_throws(TESTLOG, ErrorException, GasModels.correct_network_data!(data))
-        data["compressor"]["1"]["c_ratio_min"] = 0.5
-
-        data["compressor"]["1"]["c_ratio_max"] = 0.5
-        data["compressor"]["1"]["c_ratio_min"] = 2.5
-        @test_throws(TESTLOG, ErrorException, GasModels.correct_network_data!(data))
-        data["compressor"]["1"]["c_ratio_max"] = 2.5
-        data["compressor"]["1"]["c_ratio_min"] = 0.5
-
-        data["compressibility_factor"] = -1
-        @test_throws(TESTLOG, ErrorException, GasModels.correct_network_data!(data))
-        data["compressibility_factor"] = 0.6
-
-        data["gas_specific_gravity"] = -1
-        @test_throws(TESTLOG, ErrorException, GasModels.correct_network_data!(data))
-        data["gas_specific_gravity"] = 0.4
-    end
-
     @testset "check topology data functions" begin
-        gas_file = "../test/data/warnings.m"
+        gas_file = "../test/data/matgas/case-6.m"
         gas_data = GasModels.parse_file(gas_file)
 
         gas_data["pipe"]["2"]["status"] = 0
@@ -168,8 +107,5 @@
 
         @test gas_data["pipe"]["2"]["status"] == 0
         @test gas_data["pipe"]["4"]["status"] == 0
-        @test gas_data["delivery"]["2"]["status"] == 0
-        @test gas_data["delivery"]["4"]["status"] == 0
     end
-    =#
 end


### PR DESCRIPTION
`calc_connected_components` expected the field `junction_i` on junctions
but we have changed this to `id` in the meantime.

Added unit tests for calc_connected_components and
propagate_topology_status!