### PR TITLE
ADD: Strengthening constraints for resistors and loss resistors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Pending
 
+## v0.8.1
+
+- strengthen variable bounds for resistors and loss resistors
 
 ## v0.8
 

--- a/src/core/constraint_mi.jl
+++ b/src/core/constraint_mi.jl
@@ -214,6 +214,18 @@ function constraint_resistor_mass_flow(gm::AbstractMIModels, n::Int, k, f_min, f
 end
 
 
+#############################################################################################################
+## Constraints for modeling flow across a loss_resistor
+############################################################################################################
+"Constraint: Constraint on flow across a loss_resistor when there are on/off direction variables"
+function constraint_loss_resistor_mass_flow(gm::AbstractMIModels, n::Int, k, f_min, f_max)
+    y = var(gm, n, :y_loss_resistor, k)
+    f = var(gm, n, :f_loss_resistor, k)
+    _add_constraint!(gm, n, :on_off_loss_resistor_flow_1, k, JuMP.@constraint(gm.model, (1.0 - y) * f_min <= f))
+    _add_constraint!(gm, n, :on_off_loss_resistor_flow_2, k, JuMP.@constraint(gm.model, f <= y * f_max))
+end
+
+
 ######################################################################################
 # Constraints associated with flow through a compressor
 ######################################################################################

--- a/src/core/constraint_mi.jl
+++ b/src/core/constraint_mi.jl
@@ -215,7 +215,7 @@ end
 
 
 #############################################################################################################
-## Constraints for modeling flow across a loss_resistor
+## Constraints for modeling flow across a loss resistor
 ############################################################################################################
 "Constraint: Constraint on flow across a loss_resistor when there are on/off direction variables"
 function constraint_loss_resistor_mass_flow(gm::AbstractMIModels, n::Int, k, f_min, f_max)

--- a/src/core/constraint_mi.jl
+++ b/src/core/constraint_mi.jl
@@ -201,6 +201,18 @@ function constraint_short_pipe_mass_flow(gm::AbstractMIModels, n::Int, k, f_min,
     constraint_short_pipe_parallel_flow(gm, k; n = n)
 end
 
+#############################################################################################################
+## Constraints for modeling flow across a resistor
+############################################################################################################
+"Constraint: Constraint on flow across a resistor when there are on/off direction variables"
+function constraint_resistor_mass_flow(gm::AbstractMIModels, n::Int, k, f_min, f_max)
+    y = var(gm, n, :y_resistor, k)
+    f = var(gm, n, :f_resistor, k)
+    _add_constraint!(gm, n, :on_off_resistor_flow_1, k, JuMP.@constraint(gm.model, (1.0 - y) * f_min <= f))
+    _add_constraint!(gm, n, :on_off_resistor_flow_2, k, JuMP.@constraint(gm.model, f <= y * f_max))
+    constraint_resistor_parallel_flow(gm, k)
+end
+
 
 ######################################################################################
 # Constraints associated with flow through a compressor

--- a/src/form/crdwp.jl
+++ b/src/form/crdwp.jl
@@ -163,11 +163,16 @@ end
 function constraint_resistor_pressure(gm::AbstractCRDWPModel, n::Int, k::Int, i::Int, j::Int, pd_min::Float64, pd_max::Float64)
     p_i, p_j = var(gm, n, :p, i), var(gm, n, :p, j)
     p_i_sqr, p_j_sqr = var(gm, n, :psqr, i), var(gm, n, :psqr, j)
+    y = var(gm, n, :y_resistor, k)
 
     c_1 = JuMP.@constraint(gm.model, p_i^2 <= p_i_sqr)
     _add_constraint!(gm, n, :pressure_drop_1, k, c_1)
     c_2 = JuMP.@constraint(gm.model, p_j^2 <= p_j_sqr)
     _add_constraint!(gm, n, :pressure_drop_2, k, c_2)
+    c_3 = JuMP.@constraint(gm.model, (1.0 - y) * pd_min <= p_i - p_j)
+    _add_constraint!(gm, n, :on_off_pressure_drop_1, k, c_3)
+    c_4 = JuMP.@constraint(gm.model, p_i - p_j <= y * pd_max)
+    _add_constraint!(gm, n, :on_off_pressure_drop_2, k, c_4)
 end
 
 

--- a/src/form/dwp.jl
+++ b/src/form/dwp.jl
@@ -100,11 +100,16 @@ end
 function constraint_resistor_pressure(gm::AbstractDWPModel, n::Int, k::Int, i::Int, j::Int, pd_min::Float64, pd_max::Float64)
     p_i, p_j = var(gm, n, :p, i), var(gm, n, :p, j)
     p_i_sqr, p_j_sqr = var(gm, n, :psqr, i), var(gm, n, :psqr, j)
+    y = var(gm, n, :y_resistor, k)
 
     c_1 = JuMP.@constraint(gm.model, p_i^2 == p_i_sqr)
     _add_constraint!(gm, n, :pressure_drop_1, k, c_1)
     c_2 = JuMP.@constraint(gm.model, p_j^2 == p_j_sqr)
     _add_constraint!(gm, n, :pressure_drop_2, k, c_2)
+    c_3 = JuMP.@constraint(gm.model, (1.0 - y) * pd_min <= p_i - p_j)
+    _add_constraint!(gm, n, :on_off_pressure_drop_1, k, c_3)
+    c_4 = JuMP.@constraint(gm.model, p_i - p_j <= y * pd_max)
+    _add_constraint!(gm, n, :on_off_pressure_drop_2, k, c_4)
 end
 
 


### PR DESCRIPTION
For directed models of resistors and loss resistors, the previous implementation did not apply constraints that bounded squared pressure and mass flow variables based on flow direction. This pull request adds these constraints.