### PR TITLE
ADD: data sources table to matgas format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,16 @@
 ## Pending
 
 - bug fix in GasLib component index assignment
+- add mgc.sources to the matgas format to keep track of data source metadata
 
-## v0.8.2 
+## v0.8.2
 
 - changed default interpolation to linear
-- bug fix in reservoir constraints 
+- bug fix in reservoir constraints
 
-## v0.8.1 
+## v0.8.1
 
-- bug fix in interpolation 
+- bug fix in interpolation
 
 ## v0.8
 
@@ -19,7 +20,7 @@
 - compressors are made optional components
 - fixed bug in `calc_connected_components`
 - corrected models of resistor physics
-- added support storage model for transient_ogf added 
+- added support storage model for transient_ogf added
 - transient_ogf constraints and variables changed for improved computation times
 - renamed variable_valve_operation to be variable_on_off_operation to reflect the name change from control_valve to regulator (breaking)
 - removed explicit direction function calls. These are now handled automatically based on data

--- a/src/io/matgas.jl
+++ b/src/io/matgas.jl
@@ -18,6 +18,7 @@ const _mg_data_names = Vector{String}([
     "mgc.base_length",
     "mgc.units",
     "mgc.is_per_unit",
+    "mgc.sources",
     "mgc.junction",
     "mgc.pipe",
     "mgc.compressor",
@@ -31,6 +32,12 @@ const _mg_data_names = Vector{String}([
     "mgc.storage",
     "mgc.ne_pipe",
     "mgc.ne_compressor",
+])
+
+const _mg_sources_columns = Vector{Tuple{String,Type}}([
+    ("name", String),
+    ("agreement_year", Int),
+    ("description", String),
 ])
 
 const _mg_junction_columns = Vector{Tuple{String,Type}}([
@@ -339,6 +346,7 @@ function parse_m_string(data_string::String)
         "mgc.temperature",
         "mgc.compressibility_factor",
         "mgc.units",
+        "mgc.name",
     ]
 
     optional_metadata_names = [
@@ -751,6 +759,7 @@ end
 
 "order data types should appear in matlab format"
 const _matlab_data_order = [
+    "sources",
     "junction",
     "pipe",
     "compressor",
@@ -769,6 +778,7 @@ const _matlab_data_order = [
 
 "order data fields should appear in matlab format"
 const _matlab_field_order = Dict{String,Array}(
+    "sources" => [key for (key, dtype) in _mg_sources_columns],
     "junction" => [key for (key, dtype) in _mg_junction_columns],
     "pipe" => [key for (key, dtype) in _mg_pipe_columns],
     "compressor" => [key for (key, dtype) in _mg_compressor_columns],
@@ -787,6 +797,7 @@ const _matlab_field_order = Dict{String,Array}(
 
 "order of required global parameters"
 const _matlab_global_params_order_required = [
+    "name",
     "gas_specific_gravity",
     "specific_heat_capacity_ratio",
     "temperature",

--- a/src/io/matgas.jl
+++ b/src/io/matgas.jl
@@ -346,10 +346,10 @@ function parse_m_string(data_string::String)
         "mgc.temperature",
         "mgc.compressibility_factor",
         "mgc.units",
-        "mgc.name",
     ]
 
     optional_metadata_names = [
+        "mgc.name",
         "mgc.sound_speed",
         "mgc.R",
         "mgc.base_pressure",

--- a/src/io/transient.jl
+++ b/src/io/transient.jl
@@ -28,28 +28,38 @@ function parse_transient(io::IO)::Array{Dict{String,Any},1}
     return data
 end
 
+
+""
+function parse_files(static_file::String, transient_file::String; kwargs...)::Dict{String,Any}
+    static_filetype = split(lowercase(static_file), '.')[end]
+
+    open(static_file, "r") do static_io
+        open(transient_file, "r") do transient_io
+            return parse_files(static_io, transient_io; static_filetype=static_filetype)
+        end
+    end
+end
+
+
 """
 Parses two files - a static file and a transient csv file and prepares the data object. The static file is the .m file and the transient file is a .csv file that contains the time-series data information. The function takes in the following keyword arguments:
 (i) `total_time` (defaults to 86400 seconds or 24 hours) - this is the total time for which transient optimization needs to be solved (ii) `time_step` (defaults to 3600 seconds or 1 hours) - this argument specifies the time discretization step (iii) `spatial_discretization` (defaults to 10000 m or 10 km) - this argument specifies the spatial discretization step (iv) `additional_time` (defaults to 21600 seconds or 6 hours) - this argument decides the time horizon that needs to be padded to the total time to in case the user wishes to perform a moving horizon transient optimization.
 """
 function parse_files(
-    static_file::String,
-    transient_file::String;
+    static_io::IO,
+    transient_io::IO;
+    static_filetype::String="m",
     total_time = 86400.0,
     time_step = 3600.0,
     spatial_discretization = 10000.0,
     additional_time = 21600.0,
 )
     periodic = true
-    static_filetype = split(lowercase(static_file), '.')[end]
+
     if static_filetype == "m"
-        static_data = open(static_file) do io
-            GasModels.parse_matgas(io)
-        end
+        static_data = GasModels.parse_matgas(static_io)
     elseif static_filetype == "json"
-        static_data = open(static_file) do io
-            GasModels.parse_json(io)
-        end
+        static_data = GasModels.parse_json(static_io)
     else
         Memento.error(_LOGGER, "only .m and .json network data files are supported")
     end
@@ -69,7 +79,7 @@ function parse_files(
     check_global_parameters(static_data)
 
     _prep_transient_data!(static_data, spatial_discretization = spatial_discretization)
-    transient_data = parse_transient(transient_file)
+    transient_data = parse_transient(transient_io)
     make_si_units!(transient_data, static_data)
     time_series_block = _create_time_series_block(
         transient_data,
@@ -383,13 +393,13 @@ at least 4 time series data points are available (and result in an error otherwi
     for (type, id, param) in fields
         if (additional_time > 0.0)
             start_val = interpolators[type][id][param]["reduced_data_points"][1]
-            #= remove cubic spline interpolation 
+            #= remove cubic spline interpolation
             end_val = interpolators[type][id][param]["reduced_data_points"][end]
             middle_time = total_time + additional_time / 2
             middle_val = (end_val + start_val) / 2
             push!(interpolators[type][id][param]["times"], middle_time)
             push!(interpolators[type][id][param]["reduced_data_points"], middle_val)
-            =# 
+            =#
             push!(interpolators[type][id][param]["times"], end_time)
             push!(interpolators[type][id][param]["reduced_data_points"], start_val)
         end
@@ -424,25 +434,25 @@ function _fix_time_series_block!(block)
     for (i, val) in get(block, "transfer", [])
         if haskey(val, "withdrawal_max")
             val["withdrawal_max"] = max.(val["withdrawal_max"], zeros(length(val["withdrawal_max"])))
-        end 
+        end
         if haskey(val, "withdrawal_min")
             val["withdrawal_min"] = min.(val["withdrawal_min"], zeros(length(val["withdrawal_min"])))
-        end 
-    end 
+        end
+    end
     for (i, val) in get(block, "delivery", [])
         if haskey(val, "withdrawal_max")
             val["withdrawal_max"] = max.(val["withdrawal_max"], zeros(length(val["withdrawal_max"])))
-        end 
+        end
         if haskey(val, "withdrawal_min")
             val["withdrawal_min"] = min.(val["withdrawal_min"], zeros(length(val["withdrawal_min"])))
-        end 
+        end
     end
     for (i, val) in get(block, "receipt", [])
         if haskey(val, "injection_max")
             val["injection_max"] = max.(val["injection_max"], zeros(length(val["injection_max"])))
-        end 
+        end
         if haskey(val, "injection_min")
             val["injection_min"] = min.(val["injection_min"], zeros(length(val["injection_min"])))
-        end 
+        end
     end
-end 
+end

--- a/src/io/transient.jl
+++ b/src/io/transient.jl
@@ -1,5 +1,5 @@
 "parses transient data format CSV into list of dictionarys"
-function parse_transient(file::String)::Array{Dict{String,Any},1}
+function parse_transient(file::AbstractString)::Array{Dict{String,Any},1}
     return open(file, "r") do io
         parse_transient(io)
     end
@@ -30,7 +30,7 @@ end
 
 
 ""
-function parse_files(static_file::String, transient_file::String; kwargs...)::Dict{String,Any}
+function parse_files(static_file::AbstractString, transient_file::AbstractString; kwargs...)::Dict{String,Any}
     static_filetype = split(lowercase(static_file), '.')[end]
 
     open(static_file, "r") do static_io
@@ -48,7 +48,7 @@ Parses two files - a static file and a transient csv file and prepares the data 
 function parse_files(
     static_io::IO,
     transient_io::IO;
-    static_filetype::String="m",
+    static_filetype::AbstractString="m",
     total_time = 86400.0,
     time_step = 3600.0,
     spatial_discretization = 10000.0,

--- a/src/io/transient.jl
+++ b/src/io/transient.jl
@@ -35,7 +35,7 @@ function parse_files(static_file::AbstractString, transient_file::AbstractString
 
     open(static_file, "r") do static_io
         open(transient_file, "r") do transient_io
-            return parse_files(static_io, transient_io; static_filetype=static_filetype)
+            return parse_files(static_io, transient_io; static_filetype=static_filetype, kwargs...)
         end
     end
 end

--- a/test/data.jl
+++ b/test/data.jl
@@ -108,4 +108,13 @@
         @test gas_data["pipe"]["2"]["status"] == 0
         @test gas_data["pipe"]["4"]["status"] == 0
     end
+
+    @testset "check data sources table" begin
+        gas_file = "../test/data/matgas/case-6.m"
+        gas_data = GasModels.parse_file(gas_file)
+
+        @test haskey(gas_data, "sources")
+        @test length(gas_data["sources"]) == 1
+        @test gas_data["sources"][1]["name"] == "test" && gas_data["sources"][1]["agreement_year"] == 2020
+    end
 end

--- a/test/data/matgas/case-6.m
+++ b/test/data/matgas/case-6.m
@@ -13,6 +13,13 @@ mgc.is_per_unit                  = 0;
 mgc.economic_weighting           = 0.95;
 mgc.sound_speed                  = 371.6643;
 
+
+%% sources data
+%column_names% name agreement_year description
+mgc.sources = [
+    'test' 2020 'test data source'
+]
+
 %% junction data
 % id p_min p_max p_nominal junction_type status pipeline_name edi_id lat lon
 mgc.junction = [


### PR DESCRIPTION
To support the ability to keep and parse metadata about the source of the model in the matgas format, this adds a `sources` table that includes the headers `name`, `agreement_year`, and `description`. 

Unlike most tables in the matgas format, we don't expect sources to be indexed, and therefore the structure will remain as a list when parsed.

This also adds a version of the transient `parse_files` function that takes `IO` type arguments, instead of just string filenames. This is to support the ability to create files and load them entirely in memory.

Added unit test for mgc.sources table, unit tests of parse_files is covered by existing tests.

Updated CHANGELOG