### PR TITLE
FIX: `prep_transient_data!` gets called twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Pending
 
+- bug fix in `parse_files` where `prep_transient_data!` was called twice, overwriting `"original_pipe"` and `"original_junction"`
 - bug fix in GasLib component index assignment
 - updates for new multi-infrastructure conventions
 - add mgc.sources to the matgas format to keep track of data source metadata

--- a/src/io/transient.jl
+++ b/src/io/transient.jl
@@ -77,9 +77,8 @@ function parse_files(
     check_edge_loops(static_data)
 
     check_global_parameters(static_data)
-    prep_transient_data!(static_data)
+    prep_transient_data!(static_data; spatial_discretization=spatial_discretization)
 
-    _prep_transient_data!(static_data, spatial_discretization = spatial_discretization)
     transient_data = parse_transient(transient_io)
     make_si_units!(transient_data, static_data)
 

--- a/test/transient.jl
+++ b/test/transient.jl
@@ -10,6 +10,12 @@
     mn_data = parse_files("../test/data/matgas/case-6.m", "../test/data/transient/time-series-case-6a.csv", spatial_discretization = 1e4, additional_time = 0.0)
     @test length(mn_data["nw"]) == 25
     @test isapprox(mn_data["time_step"] * mn_data["base_time"], 3600.0; atol = 1e-3)
+
+    ss_data = parse_file("../test/data/matgas/case-6.m")
+    pipe_ids = collect(keys(ss_data["pipe"]))
+
+    @test length(first(mn_data["nw"]).second["original_pipe"]) == length(pipe_ids)
+    @test all(k in pipe_ids for k in keys(first(mn_data["nw"]).second["original_pipe"]))
 end
 
 @testset "transient (steady state replicate) case" begin


### PR DESCRIPTION
Because `prep_transient_data!` was getting called twice in `parse_files`, `"original_pipe"` and `"original_junction"` was getting overwritten and pipe discretization was being performed twice, first on the original pipes and then again on already discretized pipes.

Updates CHANGELOG and unit tests