### PR TITLE
Update transient.jl to remove typo

### DIFF
--- a/src/io/transient.jl
+++ b/src/io/transient.jl
@@ -312,7 +312,7 @@ function _prep_transient_data!(
                 "is_physical" => false,
                 "is_si_units" => data["is_si_units"],
                 "is_english_units" => data["is_english_units"],
-                "is_per_unit" => data["is_english_units"],
+                "is_per_unit" => data["is_per_units"],
                 "elevation" => h1 + (elevation_difference)*i/sub_pipe_count,
             )
         end

--- a/src/io/transient.jl
+++ b/src/io/transient.jl
@@ -337,7 +337,7 @@ function _prep_transient_data!(
                 "is_bidirectional" => pipe["is_bidirectional"],
                 "is_si_units" => data["is_si_units"],
                 "is_english_units" => data["is_english_units"],
-                "is_per_unit" => data["is_english_units"],
+                "is_per_unit" => data["is_per_units"],
                 "flow_min" => pipe["flow_min"],
                 "flow_max" => pipe["flow_max"]
             )


### PR DESCRIPTION
The line:
"is_per_unit" => data["is_english_units"]
was corrected to 
"is_per_unit" => data["is_per_units"]