### PR TITLE
add 'report_dual' to mass_flow_balance

### DIFF
--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -1,7 +1,7 @@
 # tools for working with GasModels internal data format
 
-"GasModels wrapper for the InfrastructureModels apply! function." 
-function apply_gm!(func!::Function, data::Dict{String, <:Any}; apply_to_subnetworks::Bool = true) 
+"GasModels wrapper for the InfrastructureModels apply! function."
+function apply_gm!(func!::Function, data::Dict{String, <:Any}; apply_to_subnetworks::Bool = true)
     _IM.apply!(func!, data, gm_it_name; apply_to_subnetworks = apply_to_subnetworks)
 end
 
@@ -238,6 +238,7 @@ const _params_for_unit_conversions = Dict(
         "net_injection",
         "net_nodal_edge_out_flow",
         "elevation",
+        "lam_junction_mfb"
     ],
     "original_junction" => ["p_min", "p_max", "p_nominal", "p"],
     "pipe" => [
@@ -374,7 +375,7 @@ function _rescale_functions(rescale_pressure::Function, rescale_density::Functio
         "well_density" => rescale_density,
         "length" => rescale_length,
         "well_depth" => rescale_length,
-        "elevation" => rescale_length, 
+        "elevation" => rescale_length,
         "diameter" => rescale_diameter,
         "well_diameter" => rescale_diameter,
         "f" => rescale_flow,
@@ -418,6 +419,7 @@ function _rescale_functions(rescale_pressure::Function, rescale_density::Functio
         "storage_flow" => rescale_flow,
         "bid_price" => rescale_inv_flow,
         "offer_price" => rescale_inv_flow,
+        "lam_junction_mfb" => rescale_inv_flow
     )
 end
 
@@ -1945,7 +1947,7 @@ function _select_largest_component!(data::Dict{String,<:Any})
                 Memento.info(_LOGGER, "deactivating junction $(i) due to small connected component")
             end
         end
-        
+
     end
 end
 

--- a/test/common.jl
+++ b/test/common.jl
@@ -15,3 +15,23 @@ function check_compressor_ratio(sol, gm)
         @test val["r"] >= connection["c_ratio_min"] - 1e-6
     end
 end
+
+
+"Compare number dictionaries"
+function compare(d1::Dict, d2::Dict; atol=0, rtol=0)
+    for (k,v) in d1
+        if haskey(d2, k)
+            if !compare(v, d2[k]; atol, rtol)
+                return false
+            end
+        end
+    end
+    return true
+end
+function compare(d1::Number, d2::Number; atol=0, rtol=0)
+    if !isapprox(d1, d2; atol, rtol)
+        println("Values $d1 and $d2 do not match")
+        return false
+    end
+    return true
+end


### PR DESCRIPTION
Address #288 

report_duals was not added for NE or complementarity models because duals are not supported by Juniper and I cannot test the functionality.  

I am unsure if the `make_per_unit/make_engineering_units/make_si_units` uses the right conversion value for the LMP.  