### PR TITLE
switch units flag from 1/0 to true/false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## staged 
 - nothing
 
+## v0.11.1
+- change units flags from 1 or 0 (`is_english_units = 0`) to booleans (`per_unit = true`)
+- this is a breaking change for any code that asserts/checks/modifies the units flag
+
 ## v0.11.0
 - introduce new data parsers
 - fix matgas writer

--- a/docs/src/network-data.md
+++ b/docs/src/network-data.md
@@ -10,8 +10,8 @@ The network data dictionary structure is roughly as follows:
 {
 "name":<string>,                         # a name for the model
 "temperature":<float>,                   # gas temperature. SI units are kelvin
-"per_units":<int>,                    # Whether or not the file is in per unit (non dimensional units) or SI units.
-"english_units":<int>,                # Whether or not the file is in english units
+"per_unit":<boolean>,                    # Whether or not the file is in per unit (non dimensional units) or SI units.
+"english_units":<boolean>,                # Whether or not the file is in english units
 "gas_molar_mass":<float>,                # molecular mass of the gas. SI units are kg/mol
 "gas_specific_gravity":<float>,          # the specific gravity of the gas. Non-dimensional.
 "multinetwork":<boolean>,                # flag for whether or not this is multiple networks

--- a/docs/src/network-data.md
+++ b/docs/src/network-data.md
@@ -10,8 +10,8 @@ The network data dictionary structure is roughly as follows:
 {
 "name":<string>,                         # a name for the model
 "temperature":<float>,                   # gas temperature. SI units are kelvin
-"is_per_units":<int>,                    # Whether or not the file is in per unit (non dimensional units) or SI units.
-"is_english_units":<int>,                # Whether or not the file is in english units
+"per_units":<int>,                    # Whether or not the file is in per unit (non dimensional units) or SI units.
+"english_units":<int>,                # Whether or not the file is in english units
 "gas_molar_mass":<float>,                # molecular mass of the gas. SI units are kg/mol
 "gas_specific_gravity":<float>,          # the specific gravity of the gas. Non-dimensional.
 "multinetwork":<boolean>,                # flag for whether or not this is multiple networks

--- a/docs/src/parser.md
+++ b/docs/src/parser.md
@@ -50,7 +50,7 @@ mgc.R                            = 8.314;  % J/(mol K)
 mgc.base_length                  = 5000;  % m (non-dimensionalization value)
 mgc.base_pressure                = 8101325;  % Pa (non-dimensionalization value)
 mgc.base_flow                    = 604; (non-dimensionalization value)
-mgc.per_unit                  = 0;
+mgc.per_unit                     = false;
 mgc.sound_speed                  = 312.8060
 ```
 

--- a/docs/src/parser.md
+++ b/docs/src/parser.md
@@ -50,7 +50,7 @@ mgc.R                            = 8.314;  % J/(mol K)
 mgc.base_length                  = 5000;  % m (non-dimensionalization value)
 mgc.base_pressure                = 8101325;  % Pa (non-dimensionalization value)
 mgc.base_flow                    = 604; (non-dimensionalization value)
-mgc.is_per_unit                  = 0;
+mgc.per_unit                  = 0;
 mgc.sound_speed                  = 312.8060
 ```
 

--- a/scripts/converter.jl
+++ b/scripts/converter.jl
@@ -24,7 +24,7 @@ end
 accepted_keys = ["junction"]
 for (i, junction) in data["junction"]
     junction["id"] = (get(junction, "junction_i", false) == true) ? Int(junction["junction_i"]) : parse(Int64, i)
-    if (data["per_unit"] == false)
+    if (data["per_unit"] == true)
         junction["p_min"] = junction["pmin"] * data["baseP"]
         junction["p_max"] = junction["pmax"] * data["baseP"]
         junction["p_nominal"] = (get(junction, "p", false) == true) ? junction["p"] * data["baseP"] : junction["pmin"] * data["baseP"]
@@ -82,7 +82,7 @@ for (i, compressor) in data["compressor"]
     if compressor["qmin"] == compressor["qmax"]
         compressor["qmin"] = 0.0
     end
-    if data["per_unit"] == false
+    if data["per_unit"] == true
         compressor["flow_min"] = compressor["qmin"] * data["baseQ"]
         compressor["flow_max"] = compressor["qmax"] * data["baseQ"]
     else
@@ -125,7 +125,7 @@ for (i, producer) in data["producer"]
     data["receipt"][i]["junction_id"] = (get(producer, "junction", false) != false) ? producer["junction"] : producer["qg_junc"]
     data["receipt"][i]["status"] = (get(producer, "status", false) != false) ? producer["status"] : Int(1)
     data["receipt"][i]["is_dispatchable"] = producer["dispatchable"]
-    if data["per_unit"] == false
+    if data["per_unit"] == true
         data["receipt"][i]["injection_min"] = producer["qgmin"] * data["baseQ"]
         data["receipt"][i]["injection_max"] = producer["qgmax"] * data["baseQ"]
         data["receipt"][i]["injection_nominal"] = producer["qg"] * data["baseQ"]
@@ -148,7 +148,7 @@ for (i, consumer) in data["consumer"]
     if haskey(consumer, "priority")
         data["delivery"][i]["priority"] = consumer["priority"]
     end
-    if data["per_unit"] == false
+    if data["per_unit"] == true
         data["delivery"][i]["withdrawal_min"] = consumer["qlmin"] * data["baseQ"]
         data["delivery"][i]["withdrawal_max"] = consumer["qlmax"] * data["baseQ"]
         data["delivery"][i]["withdrawal_nominal"] = consumer["ql"] * data["baseQ"]
@@ -255,7 +255,7 @@ if haskey(data, "ne_compressor")
         if compressor["qmin"] == compressor["qmax"]
             compressor["qmin"] = 0.0
         end
-        if data["per_unit"] == false
+        if data["per_unit"] == true
             compressor["flow_min"] = compressor["qmin"] * data["baseQ"]
             compressor["flow_max"] = compressor["qmax"] * data["baseQ"]
         else

--- a/scripts/converter.jl
+++ b/scripts/converter.jl
@@ -24,7 +24,7 @@ end
 accepted_keys = ["junction"]
 for (i, junction) in data["junction"]
     junction["id"] = (get(junction, "junction_i", false) == true) ? Int(junction["junction_i"]) : parse(Int64, i)
-    if (data["per_unit"] == 1)
+    if (data["per_unit"] == false)
         junction["p_min"] = junction["pmin"] * data["baseP"]
         junction["p_max"] = junction["pmax"] * data["baseP"]
         junction["p_nominal"] = (get(junction, "p", false) == true) ? junction["p"] * data["baseP"] : junction["pmin"] * data["baseP"]
@@ -82,7 +82,7 @@ for (i, compressor) in data["compressor"]
     if compressor["qmin"] == compressor["qmax"]
         compressor["qmin"] = 0.0
     end
-    if data["per_unit"] == 1
+    if data["per_unit"] == false
         compressor["flow_min"] = compressor["qmin"] * data["baseQ"]
         compressor["flow_max"] = compressor["qmax"] * data["baseQ"]
     else
@@ -125,7 +125,7 @@ for (i, producer) in data["producer"]
     data["receipt"][i]["junction_id"] = (get(producer, "junction", false) != false) ? producer["junction"] : producer["qg_junc"]
     data["receipt"][i]["status"] = (get(producer, "status", false) != false) ? producer["status"] : Int(1)
     data["receipt"][i]["is_dispatchable"] = producer["dispatchable"]
-    if data["per_unit"] == 1
+    if data["per_unit"] == false
         data["receipt"][i]["injection_min"] = producer["qgmin"] * data["baseQ"]
         data["receipt"][i]["injection_max"] = producer["qgmax"] * data["baseQ"]
         data["receipt"][i]["injection_nominal"] = producer["qg"] * data["baseQ"]
@@ -148,7 +148,7 @@ for (i, consumer) in data["consumer"]
     if haskey(consumer, "priority")
         data["delivery"][i]["priority"] = consumer["priority"]
     end
-    if data["per_unit"] == 1
+    if data["per_unit"] == false
         data["delivery"][i]["withdrawal_min"] = consumer["qlmin"] * data["baseQ"]
         data["delivery"][i]["withdrawal_max"] = consumer["qlmax"] * data["baseQ"]
         data["delivery"][i]["withdrawal_nominal"] = consumer["ql"] * data["baseQ"]
@@ -206,7 +206,7 @@ for (i, control_valve) in get(data, "control_valve", [])
         control_valve["qmin"] = -1e4
         control_valve["qmax"] = 1e4
     end
-    if data["per_unit"] == 1
+    if data["per_unit"] == false
         data["regulator"][i]["flow_min"] = control_valve["qmin"] * data["baseQ"]
         data["regulator"][i]["flow_max"] = control_valve["qmax"] * data["baseQ"]
     else
@@ -255,7 +255,7 @@ if haskey(data, "ne_compressor")
         if compressor["qmin"] == compressor["qmax"]
             compressor["qmin"] = 0.0
         end
-        if data["per_unit"] == 1
+        if data["per_unit"] == false
             compressor["flow_min"] = compressor["qmin"] * data["baseQ"]
             compressor["flow_max"] = compressor["qmax"] * data["baseQ"]
         else
@@ -296,9 +296,9 @@ push!(accepted_keys, "sound_speed")
 push!(accepted_keys, "R")
 push!(accepted_keys, "compressibility_factor")
 push!(accepted_keys, "units")
-push!(accepted_keys, "is_per_unit")
-push!(accepted_keys, "is_si_units")
-push!(accepted_keys, "is_english_units")
+push!(accepted_keys, "per_unit")
+push!(accepted_keys, "si_units")
+push!(accepted_keys, "english_units")
 push!(accepted_keys, "economic_weighting")
 push!(accepted_keys, "base_pressure")
 push!(accepted_keys, "base_length")
@@ -339,9 +339,9 @@ end
 data["base_pressure"] = data["baseP"]
 data["base_length"] = 5000.0
 data["base_flow"] = data["baseQ"]
-data["is_per_unit"] = 0
-data["is_si_units"] = 1
-data["is_english_units"] = 0
+data["per_unit"] = false
+data["si_units"] = true
+data["english_units"] = false
 data["units"] = "si"
 
 

--- a/src/GasModels.jl
+++ b/src/GasModels.jl
@@ -39,7 +39,7 @@ module GasModels
         "temperature", "sound_speed", "compressibility_factor", "R",
         "base_pressure", "base_length", "base_flow", "base_time",
         "base_flux", "base_density", "base_diameter", "base_volume", "base_mass",
-        "units", "is_per_unit", "is_english_units", "is_si_units",
+        "units", "per_unit", "english_units", "si_units",
         "num_time_points", "time_step", "num_physical_time_points", "gas_molar_mass",
         "economic_weighting"])
 

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -96,7 +96,7 @@ end
 
 "if original data is in per-unit ensure it has base values"
 function _per_unit_data_field_check!(data::Dict{String,Any})
-    if get(data, "is_per_unit", false) == true
+    if get(data, "per_unit", false) == true
         if get(data, "base_pressure", false) == false || get(data, "base_length", false) == false
             Memento.error(_LOGGER, "data in .m file is in per unit but no base_pressure (in Pa) and base_length (in m) values are provided")
         else
@@ -448,24 +448,24 @@ function si_to_pu!(data::Dict{String,<:Any}; id = "0")
 
     for (component, parameters) in _params_for_unit_conversions
         for (i, comp) in get(gm_nw_data, component, [])
-            if !haskey(comp, "is_per_unit") && !haskey(gm_data, "is_per_unit")
+            if !haskey(comp, "per_unit") && !haskey(gm_data, "per_unit")
                 Memento.error(_LOGGER, "the current units of the data/result dictionary unknown")
             end
 
-            if !haskey(comp, "is_per_unit") && haskey(gm_data, "is_per_unit")
-                comp["is_per_unit"] = gm_data["is_per_unit"]
-                comp["is_si_units"] = 0
-                comp["is_english_units"] = 0
+            if !haskey(comp, "per_unit") && haskey(gm_data, "per_unit")
+                comp["per_unit"] = gm_data["per_unit"]
+                comp["si_units"] = false
+                comp["english_units"] = false
             end
 
-            if comp["is_si_units"] == true && comp["is_per_unit"] == false
+            if comp["si_units"] == true && comp["per_unit"] == false
                 for param in parameters
                     _apply_func!(comp, param, functions[param])
                 end
 
-                comp["is_si_units"] = 0
-                comp["is_english_units"] = 0
-                comp["is_per_unit"] = 1
+                comp["si_units"] = false
+                comp["english_units"] = false
+                comp["per_unit"] = true
             end
         end
     end
@@ -497,23 +497,23 @@ function pu_to_si!(data::Dict{String,<:Any}; id = "0")
 
     for (component, parameters) in _params_for_unit_conversions
         for (i, comp) in get(gm_nw_data, component, [])
-            if !haskey(comp, "is_per_unit") && !haskey(gm_data, "is_per_unit")
+            if !haskey(comp, "per_unit") && !haskey(gm_data, "per_unit")
                 Memento.error(_LOGGER, "the current units of the data/result dictionary unknown")
             end
 
-            if !haskey(comp, "is_per_unit") && haskey(gm_data, "is_per_unit")
-                @assert gm_data["is_per_unit"] == 1
-                comp["is_per_unit"] = gm_data["is_per_unit"]
-                comp["is_si_units"] = 0
-                comp["is_english_units"] = 0
+            if !haskey(comp, "per_unit") && haskey(gm_data, "per_unit")
+                @assert gm_data["per_unit"] == true
+                comp["per_unit"] = gm_data["per_unit"]
+                comp["si_units"] = false
+                comp["english_units"] = false
             end
 
-            if comp["is_si_units"] == false && comp["is_per_unit"] == true
+            if comp["si_units"] == false && comp["per_unit"] == true
                 for param in parameters
                     _apply_func!(comp, param, functions[param])
-                    comp["is_si_units"] = 1
-                    comp["is_english_units"] = 0
-                    comp["is_per_unit"] = 0
+                    comp["si_units"] = true
+                    comp["english_units"] = false
+                    comp["per_unit"] = false
                 end
             end
         end
@@ -544,23 +544,23 @@ function si_to_english!(data::Dict{String,<:Any}; id = "0")
 
     for (component, parameters) in _params_for_unit_conversions
         for (i, comp) in get(gm_nw_data, component, [])
-            if !haskey(comp, "is_per_unit") && !haskey(gm_data, "is_per_unit")
+            if !haskey(comp, "per_unit") && !haskey(gm_data, "per_unit")
                 Memento.error(_LOGGER, "the current units of the data/result dictionary unknown")
             end
 
-            if !haskey(comp, "is_per_unit") && haskey(gm_data, "is_per_unit")
-                @assert gm_data["is_per_unit"] == 1
-                comp["is_per_unit"] = gm_data["is_per_unit"]
-                comp["is_si_units"] = 0
-                comp["is_english_units"] = 0
+            if !haskey(comp, "per_unit") && haskey(gm_data, "per_unit")
+                @assert gm_data["per_unit"] == true
+                comp["per_unit"] = gm_data["per_unit"]
+                comp["si_units"] = false
+                comp["english_units"] = false
             end
 
-            if comp["is_english_units"] == false && comp["is_si_units"] == true
+            if comp["english_units"] == false && comp["si_units"] == true
                 for param in parameters
                     _apply_func!(comp, param, functions[param])
-                    comp["is_si_units"] = 0
-                    comp["is_english_units"] = 1
-                    comp["is_per_unit"] = 0
+                    comp["si_units"] = false
+                    comp["english_units"] = true
+                    comp["per_unit"] = false
                 end
             end
         end
@@ -591,23 +591,23 @@ function english_to_si!(data::Dict{String,<:Any}; id = "0")
 
     for (component, parameters) in _params_for_unit_conversions
         for (i, comp) in get(gm_nw_data, component, [])
-            if !haskey(comp, "is_per_unit") && !haskey(gm_data, "is_per_unit")
+            if !haskey(comp, "per_unit") && !haskey(gm_data, "per_unit")
                 Memento.error(_LOGGER, "the current units of the data/result dictionary unknown")
             end
 
-            if !haskey(comp, "is_per_unit") && haskey(gm_data, "is_per_unit")
-                @assert gm_data["is_per_unit"] == 1
-                comp["is_per_unit"] = gm_data["is_per_unit"]
-                comp["is_si_units"] = 0
-                comp["is_english_units"] = 0
+            if !haskey(comp, "per_unit") && haskey(gm_data, "per_unit")
+                @assert gm_data["per_unit"] == true
+                comp["per_unit"] = gm_data["per_unit"]
+                comp["si_units"] = false
+                comp["english_units"] = false
             end
 
-            if comp["is_english_units"] == true && comp["is_si_units"] == false
+            if comp["english_units"] == true && comp["si_units"] == false
                 for param in parameters
                     _apply_func!(comp, param, functions[param])
-                    comp["is_si_units"] = 1
-                    comp["is_english_units"] = 0
-                    comp["is_per_unit"] = 0
+                    comp["si_units"] = true
+                    comp["english_units"] = false
+                    comp["per_unit"] = false
                 end
             end
         end
@@ -623,11 +623,11 @@ end
 
 "transforms data to si units"
 function _make_si_units!(data::Dict{String,<:Any})
-    if get(data, "is_si_units", false) == true
+    if get(data, "si_units", false) == true
         return
     end
 
-    if get(data, "is_per_unit", false) == true
+    if get(data, "per_unit", false) == true
         if _IM.ismultinetwork(data)
             for (i, _) in data["nw"]
                 pu_to_si!(data, id = i)
@@ -641,12 +641,12 @@ function _make_si_units!(data::Dict{String,<:Any})
             data["time_step"] = rescale_time(data["time_step"])
         end
 
-        data["is_si_units"] = 1
-        data["is_english_units"] = 0
-        data["is_per_unit"] = 0
+        data["si_units"] = true
+        data["english_units"] = false
+        data["per_unit"] = false
     end
 
-    if get(data, "is_english_units", false) == true
+    if get(data, "english_units", false) == true
         if _IM.ismultinetwork(data)
             for (i, _) in data["nw"]
                 english_to_si!(data, id = i)
@@ -655,9 +655,9 @@ function _make_si_units!(data::Dict{String,<:Any})
             english_to_si!(data)
         end
 
-        data["is_si_units"] = 1
-        data["is_english_units"] = 0
-        data["is_per_unit"] = 0
+        data["si_units"] = true
+        data["english_units"] = false
+        data["per_unit"] = false
     end
 end
 
@@ -669,15 +669,15 @@ end
 
 "Transforms network data into English units"
 function _make_english_units!(data::Dict{String, <:Any})
-    if get(data, "is_english_units", false) == true
+    if get(data, "english_units", false) == true
         return
     end
 
-    if get(data, "is_per_unit", false) == true
+    if get(data, "per_unit", false) == true
         make_si_units!(data)
     end
 
-    if get(data, "is_si_units", false) == true
+    if get(data, "si_units", false) == true
         if _IM.ismultinetwork(data)
             for (i, _) in data["nw"]
                 si_to_english!(data, id = i)
@@ -686,9 +686,9 @@ function _make_english_units!(data::Dict{String, <:Any})
             si_to_english!(data)
         end
 
-        data["is_si_units"] = 0
-        data["is_english_units"] = 1
-        data["is_per_unit"] = 0
+        data["si_units"] = false
+        data["english_units"] = true
+        data["per_unit"] = false
     end
 end
 
@@ -701,15 +701,15 @@ end
 
 "Transforms network data into per unit"
 function _make_per_unit!(data::Dict{String,<:Any})
-    if get(data, "is_per_unit", false) == true
+    if get(data, "per_unit", false) == true
         return
     end
 
-    if get(data, "is_english_units", false) == true
+    if get(data, "english_units", false) == true
         make_si_units!(data)
     end
 
-    if get(data, "is_si_units", false) == true
+    if get(data, "si_units", false) == true
         if _IM.ismultinetwork(data)
             for (i, _) in data["nw"]
                 si_to_pu!(data, id = i)
@@ -723,9 +723,9 @@ function _make_per_unit!(data::Dict{String,<:Any})
             data["time_step"] = rescale_time(data["time_step"])
         end
 
-        data["is_si_units"] = 0
-        data["is_english_units"] = 0
-        data["is_per_unit"] = 1
+        data["si_units"] = false
+        data["english_units"] = false
+        data["per_unit"] = true
     end
 end
 
@@ -947,30 +947,30 @@ function _correct_p_mins!(data::Dict{String,Any}; si_value = 1.37e6, english_val
     for (i, junction) in get(data, "junction", [])
         if junction["p_min"] < 0.0
             Memento.warn(_LOGGER, "junction $i's p_min changed to 1.37E6 Pa (200 PSI) from < 0")
-            (data["is_si_units"] == 1) && (junction["p_min"] = si_value)
-            (data["is_english_units"] == 1) && (junction["p_min"] = english_value)
+            (data["si_units"] == true) && (junction["p_min"] = si_value)
+            (data["english_units"] == true) && (junction["p_min"] = english_value)
         end
     end
 
     for (i, pipe) in get(data, "pipe", [])
         if pipe["p_min"] < 0.0
             Memento.warn(_LOGGER, "pipe $i's p_min changed to 1.37E6 Pa (200 PSI) from < 0")
-            (data["is_si_units"] == 1) && (pipe["p_min"] = si_value)
-            (data["is_english_units"] == 1) && (pipe["p_min"] = english_value)
+            (data["si_units"] == true) && (pipe["p_min"] = si_value)
+            (data["english_units"] == true) && (pipe["p_min"] = english_value)
         end
     end
 
     for (i, compressor) in get(data, "compressor", [])
         if compressor["inlet_p_min"] < 0
             Memento.warn(_LOGGER, "compressor $i's inlet_p_min changed to 1.37E6 Pa (200 PSI) from < 0")
-            (data["is_si_units"] == 1) && (compressor["inlet_p_min"] = si_value)
-            (data["is_english_units"] == 1) && (compressor["inlet_p_min"] = english_value)
+            (data["si_units"] == true) && (compressor["inlet_p_min"] = si_value)
+            (data["english_units"] == true) && (compressor["inlet_p_min"] = english_value)
         end
 
         if compressor["outlet_p_min"] < 0
             Memento.warn(_LOGGER, "compressor $i's outlet_p_min changed to 1.37E6 Pa (200 PSI) from < 0")
-            (data["is_si_units"] == 1) && (compressor["outlet_p_min"] = si_value)
-            (data["is_english_units"] == 1) && (compressor["outlet_p_min"] = english_value)
+            (data["si_units"] == true) && (compressor["outlet_p_min"] = si_value)
+            (data["english_units"] == true) && (compressor["outlet_p_min"] = english_value)
         end
     end
 end
@@ -984,25 +984,25 @@ end
 
 "add additional compressor fields - required for transient"
 function _add_compressor_fields!(data::Dict{String,<:Any})
-    is_si_units = get(data, "is_si_units", 0)
-    is_english_units = get(data, "is_english_units", 0)
-    is_per_unit = get(data, "is_per_unit", false)
+    si_units = get(data, "si_units", 0)
+    english_units = get(data, "english_units", 0)
+    per_unit = get(data, "per_unit", false)
 
     if haskey(data, "compressor")
         for (i, compressor) in data["compressor"]
-            if is_si_units == true
+            if si_units == true
                 compressor["diameter"] = 1.0
                 compressor["length"] = 250.0
                 compressor["friction_factor"] = 0.001
             end
 
-            if is_english_units == true
+            if english_units == true
                 compressor["diameter"] = 39.37
                 compressor["length"] = 0.16
                 compressor["friction_factor"] = 0.001
             end
 
-            if is_per_unit == true
+            if per_unit == true
                 base_length = get(data, "base_length", 5000.0)
                 compressor["diameter"] = 1.0
                 compressor["length"] = 250.0 / base_length
@@ -1013,19 +1013,19 @@ function _add_compressor_fields!(data::Dict{String,<:Any})
 
     if haskey(data, "ne_compressor")
         for (i, compressor) in data["ne_compressor"]
-            if is_si_units == true
+            if si_units == true
                 compressor["diameter"] = 1.0
                 compressor["length"] = 250.0
                 compressor["friction_factor"] = 0.001
             end
 
-            if is_english_units == true
+            if english_units == true
                 compressor["diameter"] = 39.37
                 compressor["length"] = 0.16
                 compressor["friction_factor"] = 0.001
             end
 
-            if is_per_unit == true
+            if per_unit == true
                 base_length = get(data, "base_length", 5000.0)
                 compressor["diameter"] = 1.0
                 compressor["length"] = 250.0 / base_length

--- a/src/core/solution.jl
+++ b/src/core/solution.jl
@@ -1,5 +1,5 @@
 function _IM.solution_preprocessor(gm::AbstractGasModel, solution::Dict)
-    solution["it"][gm_it_name]["is_per_unit"] = get_data_gm((x -> return x["is_per_unit"]), gm.data; apply_to_subnetworks = false)
+    solution["it"][gm_it_name]["per_unit"] = get_data_gm((x -> return x["per_unit"]), gm.data; apply_to_subnetworks = false)
     solution["it"][gm_it_name]["multinetwork"] = ismultinetwork(gm)
     solution["it"][gm_it_name]["base_pressure"] = gm.ref[:it][gm_it_sym][:base_pressure]
     solution["it"][gm_it_name]["base_flow"] = gm.ref[:it][gm_it_sym][:base_flow]

--- a/src/io/gaslib.jl
+++ b/src/io/gaslib.jl
@@ -88,9 +88,9 @@ function parse_gaslib(zip_path::Union{IO,String})
         "loss_resistor" => loss_resistors,
         "short_pipe" => short_pipes,
         "valve" => valves,
-        "is_si_units" => 1,
-        "is_english_units" => 0,
-        "is_per_unit" => 0,
+        "si_units" => true,
+        "english_units" => 0,
+        "per_unit" => false,
         "sound_speed" => sound_speed,
         "temperature" => temperature,
         "name" => name,
@@ -293,7 +293,7 @@ function _get_compressor_entry(
     power_max = H_max * abs(flow_max) * inv(0.1)
 
     return Dict{String,Any}(
-        "is_per_unit" => 0,
+        "per_unit" => false,
         "fr_junction" => fr_junction,
         "to_junction" => to_junction,
         "inlet_p_min" => inlet_p_min,
@@ -305,8 +305,8 @@ function _get_compressor_entry(
         "diameter" => diameter,
         "directionality" => directionality,
         "status" => 1,
-        "is_si_units" => 1,
-        "is_english_units" => 0,
+        "si_units" => true,
+        "english_units" => 0,
         "c_ratio_min" => c_ratio_min,
         "c_ratio_max" => c_ratio_max,
         "power_max" => power_max,
@@ -333,10 +333,10 @@ function _get_delivery_entry(delivery, density::Float64)
         "withdrawal_max" => withdrawal_max,
         "withdrawal_nominal" => withdrawal_max,
         "is_dispatchable" => is_dispatchable,
-        "is_per_unit" => 0,
+        "per_unit" => false,
         "status" => 1,
-        "is_si_units" => 1,
-        "is_english_units" => 0,
+        "si_units" => true,
+        "english_units" => 0,
         "junction_id" => delivery[:id],
     )
 end
@@ -361,9 +361,9 @@ function _get_junction_entry(junction)
         "is_dispatchable" => 0,
         "status" => 1,
         "junction_type" => 0,
-        "is_per_unit" => 0,
-        "is_si_units" => 1,
-        "is_english_units" => 0,
+        "per_unit" => false,
+        "si_units" => true,
+        "english_units" => 0,
         "edi_id" => junction[:id],
         "id" => junction[:id],
         "index" => junction[:id],
@@ -425,9 +425,9 @@ function _get_pipe_entry(pipe, junctions, density::Float64)
         "friction_factor" => friction_factor,
         "is_bidirectional" => is_bidirectional,
         "status" => 1,
-        "is_per_unit" => 0,
-        "is_si_units" => 1,
-        "is_english_units" => 0,
+        "per_unit" => false,
+        "si_units" => true,
+        "english_units" => 0,
     )
 end
 
@@ -451,10 +451,10 @@ function _get_loss_resistor_entry(loss_resistor, density::Float64)
         "flow_min" => flow_min,
         "flow_max" => flow_max,
         "p_loss" => p_loss,
-        "is_per_unit" => 0,
+        "per_unit" => false,
         "status" => 1,
-        "is_si_units" => 1,
-        "is_english_units" => 0,
+        "si_units" => true,
+        "english_units" => 0,
         "is_bidirectional" => is_bidirectional,
     )
 end
@@ -476,10 +476,10 @@ function _get_short_pipe_entry(short_pipe, density::Float64)
         "fr_junction" => fr_junction,
         "to_junction" => to_junction,
         "is_bidirectional" => is_bidirectional,
-        "is_per_unit" => 0,
+        "per_unit" => false,
         "status" => 1,
-        "is_si_units" => 1,
-        "is_english_units" => 0,
+        "si_units" => true,
+        "english_units" => 0,
     )
 end
 
@@ -502,10 +502,10 @@ function _get_receipt_entry(receipt, density::Float64)
         "injection_max" => injection_max,
         "injection_nominal" => injection_max,
         "is_dispatchable" => is_dispatchable,
-        "is_per_unit" => 0,
+        "per_unit" => false,
         "status" => 1,
-        "is_si_units" => 1,
-        "is_english_units" => 0,
+        "si_units" => true,
+        "english_units" => 0,
         "junction_id" => receipt[:id],
     )
 end
@@ -532,10 +532,10 @@ function _get_resistor_entry(resistor, density::Float64)
         "flow_max" => flow_max,
         "drag" => drag,
         "diameter" => diameter,
-        "is_per_unit" => 0,
+        "per_unit" => false,
         "status" => 1,
-        "is_si_units" => 1,
-        "is_english_units" => 0,
+        "si_units" => true,
+        "english_units" => 0,
         "is_bidirectional" => is_bidirectional,
     )
 end
@@ -555,13 +555,13 @@ function _get_valve_entry(valve, density::Float64)
 
     return Dict{String,Any}(
         "fr_junction" => fr_junction,
-        "is_english_units" => 0,
+        "english_units" => 0,
         "to_junction" => to_junction,
         "flow_min" => flow_min,
         "flow_max" => flow_max,
         "status" => 1,
-        "is_per_unit" => 0,
-        "is_si_units" => 1,
+        "per_unit" => false,
+        "si_units" => true,
         "is_bidirectional" => is_bidirectional,
     )
 end
@@ -587,16 +587,16 @@ function _get_regulator_entry(regulator, density::Float64)
 
     return Dict{String,Any}(
         "fr_junction" => fr_junction,
-        "is_english_units" => 0,
+        "english_units" => 0,
         "to_junction" => to_junction,
         "flow_min" => flow_min,
-        "is_si_units" => 1,
+        "si_units" => true,
         "flow_max" => flow_max,
         "reduction_factor_min" => reduction_factor_min,
         "reduction_factor_max" => reduction_factor_max,
         "status" => 1,
         "is_bidirectional" => is_bidirectional,
-        "is_per_unit" => 0,
+        "per_unit" => false,
         "bypass_required" => bypass_required,
     )
 end

--- a/src/io/matgas.jl
+++ b/src/io/matgas.jl
@@ -404,10 +404,10 @@ This value will be auto-assigned based on the pressure limits provided in the da
             This value will be auto-assigned based on the pipe data"))
     end
 
-    if haskey(matlab_data, "mgc.per_unit")
-        case["per_unit"] = matlab_data["mgc.per_unit"]
+    if haskey(matlab_data, "mgc.is_per_unit")
+        case["per_unit"] = matlab_data["mgc.is_per_unit"]
     else
-        Memento.warn(_LOGGER, string("no per_unit found in .m file.
+        Memento.warn(_LOGGER, string("no is_per_unit found in .m file.
             Auto assigning a value of 0 (false) for the per_unit field"))
         case["per_unit"] = false
     end

--- a/src/io/matgas.jl
+++ b/src/io/matgas.jl
@@ -18,7 +18,7 @@ const _mg_data_names = Vector{String}([
     "mgc.base_pressure",
     "mgc.base_length",
     "mgc.units",
-    "mgc.is_per_unit",
+    "mgc.per_unit",
     "mgc.sources",
     "mgc.junction",
     "mgc.pipe",
@@ -355,7 +355,7 @@ function parse_m_string(data_string::String)
         "mgc.R",
         "mgc.base_pressure",
         "mgc.base_length",
-        "mgc.is_per_unit",
+        "mgc.per_unit",
         "mgc.gas_molar_mass",
         "mgc.economic_weighting",
     ]
@@ -372,11 +372,11 @@ function parse_m_string(data_string::String)
     if haskey(matlab_data, "mgc.units")
         case["units"] = matlab_data["mgc.units"]
         if matlab_data["mgc.units"] == "si"
-            case["is_si_units"] = 1
-            case["is_english_units"] = 0
+            case["si_units"] = true
+            case["english_units"] = false
         elseif matlab_data["mgc.units"] == "usc"
-            case["is_english_units"] = 1
-            case["is_si_units"] = 0
+            case["english_units"] = true
+            case["si_units"] = false
         else
             Memento.error(_LOGGER, string("the possible values for units field in .m file are \"si\" or \"usc\""))
         end
@@ -404,12 +404,12 @@ This value will be auto-assigned based on the pressure limits provided in the da
             This value will be auto-assigned based on the pipe data"))
     end
 
-    if haskey(matlab_data, "mgc.is_per_unit")
-        case["is_per_unit"] = matlab_data["mgc.is_per_unit"]
+    if haskey(matlab_data, "mgc.per_unit")
+        case["per_unit"] = matlab_data["mgc.per_unit"]
     else
-        Memento.warn(_LOGGER, string("no is_per_unit found in .m file.
-            Auto assigning a value of 0 (false) for the is_per_unit field"))
-        case["is_per_unit"] = 0
+        Memento.warn(_LOGGER, string("no per_unit found in .m file.
+            Auto assigning a value of 0 (false) for the per_unit field"))
+        case["per_unit"] = false
     end
 
     if haskey(matlab_data, "mgc.R")
@@ -463,9 +463,9 @@ objective is economic_weighting * (load shed) +
                 get(_colnames, "mgc.junction", _mg_junction_columns),
             )
             junction_data["index"] = _IM.check_type(Int, junction_row[1])
-            junction_data["is_si_units"] = case["is_si_units"]
-            junction_data["is_english_units"] = case["is_english_units"]
-            junction_data["is_per_unit"] = case["is_per_unit"]
+            junction_data["si_units"] = case["si_units"]
+            junction_data["english_units"] = case["english_units"]
+            junction_data["per_unit"] = case["per_unit"]
             push!(junctions, junction_data)
         end
         case["junction"] = junctions
@@ -482,9 +482,9 @@ objective is economic_weighting * (load shed) +
                 get(_colnames, "mgc.pipe", _mg_pipe_columns),
             )
             pipe_data["index"] = _IM.check_type(Int, pipe_row[1])
-            pipe_data["is_si_units"] = case["is_si_units"]
-            pipe_data["is_english_units"] = case["is_english_units"]
-            pipe_data["is_per_unit"] = case["is_per_unit"]
+            pipe_data["si_units"] = case["si_units"]
+            pipe_data["english_units"] = case["english_units"]
+            pipe_data["per_unit"] = case["per_unit"]
             push!(pipes, pipe_data)
         end
         case["pipe"] = pipes
@@ -501,9 +501,9 @@ objective is economic_weighting * (load shed) +
                 get(_colnames, "mgc.ne_pipe", _mg_ne_pipe_columns),
             )
             pipe_data["index"] = _IM.check_type(Int, pipe_row[1])
-            pipe_data["is_si_units"] = case["is_si_units"]
-            pipe_data["is_english_units"] = case["is_english_units"]
-            pipe_data["is_per_unit"] = case["is_per_unit"]
+            pipe_data["si_units"] = case["si_units"]
+            pipe_data["english_units"] = case["english_units"]
+            pipe_data["per_unit"] = case["per_unit"]
             push!(ne_pipes, pipe_data)
         end
         case["ne_pipe"] = ne_pipes
@@ -517,9 +517,9 @@ objective is economic_weighting * (load shed) +
                 get(_colnames, "mgc.compressor", _mg_compressor_columns),
             )
             compressor_data["index"] = _IM.check_type(Int, compressor_row[1])
-            compressor_data["is_si_units"] = case["is_si_units"]
-            compressor_data["is_english_units"] = case["is_english_units"]
-            compressor_data["is_per_unit"] = case["is_per_unit"]
+            compressor_data["si_units"] = case["si_units"]
+            compressor_data["english_units"] = case["english_units"]
+            compressor_data["per_unit"] = case["per_unit"]
             push!(compressors, compressor_data)
         end
         case["compressor"] = compressors
@@ -533,9 +533,9 @@ objective is economic_weighting * (load shed) +
                 get(_colnames, "mgc.ne_compressor", _mg_ne_compressor_columns),
             )
             compressor_data["index"] = _IM.check_type(Int, compressor_row[1])
-            compressor_data["is_si_units"] = case["is_si_units"]
-            compressor_data["is_english_units"] = case["is_english_units"]
-            compressor_data["is_per_unit"] = case["is_per_unit"]
+            compressor_data["si_units"] = case["si_units"]
+            compressor_data["english_units"] = case["english_units"]
+            compressor_data["per_unit"] = case["per_unit"]
             push!(ne_compressors, compressor_data)
         end
         case["ne_compressor"] = ne_compressors
@@ -549,9 +549,9 @@ objective is economic_weighting * (load shed) +
                 get(_colnames, "mgc.short_pipe", _mg_short_pipe_columns),
             )
             short_pipe_data["index"] = _IM.check_type(Int, short_pipe_row[1])
-            short_pipe_data["is_si_units"] = case["is_si_units"]
-            short_pipe_data["is_english_units"] = case["is_english_units"]
-            short_pipe_data["is_per_unit"] = case["is_per_unit"]
+            short_pipe_data["si_units"] = case["si_units"]
+            short_pipe_data["english_units"] = case["english_units"]
+            short_pipe_data["per_unit"] = case["per_unit"]
             push!(short_pipes, short_pipe_data)
         end
         case["short_pipe"] = short_pipes
@@ -565,9 +565,9 @@ objective is economic_weighting * (load shed) +
                 get(_colnames, "mgc.resistor", _mg_resistor_columns),
             )
             resistor_data["index"] = _IM.check_type(Int, resistor_row[1])
-            resistor_data["is_si_units"] = case["is_si_units"]
-            resistor_data["is_english_units"] = case["is_english_units"]
-            resistor_data["is_per_unit"] = case["is_per_unit"]
+            resistor_data["si_units"] = case["si_units"]
+            resistor_data["english_units"] = case["english_units"]
+            resistor_data["per_unit"] = case["per_unit"]
             push!(resistors, resistor_data)
         end
         case["resistor"] = resistors
@@ -581,9 +581,9 @@ objective is economic_weighting * (load shed) +
                 get(_colnames, "mgc.transfer", _mg_transfer_columns),
             )
             transfer_data["index"] = _IM.check_type(Int, transfer_row[1])
-            transfer_data["is_si_units"] = case["is_si_units"]
-            transfer_data["is_english_units"] = case["is_english_units"]
-            transfer_data["is_per_unit"] = case["is_per_unit"]
+            transfer_data["si_units"] = case["si_units"]
+            transfer_data["english_units"] = case["english_units"]
+            transfer_data["per_unit"] = case["per_unit"]
             push!(transfers, transfer_data)
         end
         case["transfer"] = transfers
@@ -597,9 +597,9 @@ objective is economic_weighting * (load shed) +
                 get(_colnames, "mgc.receipt", _mg_receipt_columns),
             )
             receipt_data["index"] = _IM.check_type(Int, receipt_row[1])
-            receipt_data["is_si_units"] = case["is_si_units"]
-            receipt_data["is_english_units"] = case["is_english_units"]
-            receipt_data["is_per_unit"] = case["is_per_unit"]
+            receipt_data["si_units"] = case["si_units"]
+            receipt_data["english_units"] = case["english_units"]
+            receipt_data["per_unit"] = case["per_unit"]
             push!(receipts, receipt_data)
         end
         case["receipt"] = receipts
@@ -613,9 +613,9 @@ objective is economic_weighting * (load shed) +
                 get(_colnames, "mgc.delivery", _mg_delivery_columns),
             )
             delivery_data["index"] = _IM.check_type(Int, delivery_row[1])
-            delivery_data["is_si_units"] = case["is_si_units"]
-            delivery_data["is_english_units"] = case["is_english_units"]
-            delivery_data["is_per_unit"] = case["is_per_unit"]
+            delivery_data["si_units"] = case["si_units"]
+            delivery_data["english_units"] = case["english_units"]
+            delivery_data["per_unit"] = case["per_unit"]
             push!(deliveries, delivery_data)
         end
         case["delivery"] = deliveries
@@ -629,9 +629,9 @@ objective is economic_weighting * (load shed) +
                 get(_colnames, "mgc.regulator", _mg_regulator_columns),
             )
             regulator_data["index"] = _IM.check_type(Int, regulator_row[1])
-            regulator_data["is_si_units"] = case["is_si_units"]
-            regulator_data["is_english_units"] = case["is_english_units"]
-            regulator_data["is_per_unit"] = case["is_per_unit"]
+            regulator_data["si_units"] = case["si_units"]
+            regulator_data["english_units"] = case["english_units"]
+            regulator_data["per_unit"] = case["per_unit"]
             push!(regulators, regulator_data)
         end
         case["regulator"] = regulators
@@ -645,9 +645,9 @@ objective is economic_weighting * (load shed) +
                 get(_colnames, "mgc.valve", _mg_valve_columns),
             )
             valve_data["index"] = _IM.check_type(Int, valve_row[1])
-            valve_data["is_si_units"] = case["is_si_units"]
-            valve_data["is_english_units"] = case["is_english_units"]
-            valve_data["is_per_unit"] = case["is_per_unit"]
+            valve_data["si_units"] = case["si_units"]
+            valve_data["english_units"] = case["english_units"]
+            valve_data["per_unit"] = case["per_unit"]
             push!(valves, valve_data)
         end
         case["valve"] = valves
@@ -661,9 +661,9 @@ objective is economic_weighting * (load shed) +
                 get(_colnames, "mgc.storage", _mg_storage_columns),
             )
             storage_data["index"] = _IM.check_type(Int, storage_row[1])
-            storage_data["is_si_units"] = case["is_si_units"]
-            storage_data["is_english_units"] = case["is_english_units"]
-            storage_data["is_per_unit"] = case["is_per_unit"]
+            storage_data["si_units"] = case["si_units"]
+            storage_data["english_units"] = case["english_units"]
+            storage_data["per_unit"] = case["per_unit"]
             push!(storages, storage_data)
         end
         case["storage"] = storages
@@ -837,7 +837,7 @@ const _matlab_global_params_order_required = [
 
 
 "order of optional global parameters"
-const _matlab_global_params_order_optional = ["sound_speed", "R", "base_pressure", "base_length", "is_per_unit", "version", "pipeline_id", "base_volume", "economic_weighting"]
+const _matlab_global_params_order_optional = ["sound_speed", "R", "base_pressure", "base_length", "per_unit", "version", "pipeline_id", "base_volume", "economic_weighting"]
 
 
 "list of units of meta data fields"
@@ -937,7 +937,7 @@ function _gasmodels_to_matgas_string(
         include_extended::Bool = false,
     )::String
 
-    (data["is_english_units"] == true) && (units = "usc")
+    (data["english_units"] == true) && (units = "usc")
     lines = ["function mgc = $(replace(data["name"], " " => "_"))", ""]
 
     for param in _matlab_global_params_order_required

--- a/src/io/transient.jl
+++ b/src/io/transient.jl
@@ -252,9 +252,9 @@ function _prep_transient_data!(
                 "p_max",
                 "status",
                 "is_bidirectional",
-                "is_si_units",
-                "is_english_units",
-                "is_per_unit",
+                "si_units",
+                "english_units",
+                "per_unit",
                 "flow_min", 
                 "flow_max"
             ]
@@ -306,9 +306,9 @@ function _prep_transient_data!(
                 "junction_type" => 0,
                 "status" => 1,
                 "is_physical" => false,
-                "is_si_units" => data["is_si_units"],
-                "is_english_units" => data["is_english_units"],
-                "is_per_unit" => data["is_per_unit"],
+                "si_units" => data["si_units"],
+                "english_units" => data["english_units"],
+                "per_unit" => data["per_unit"],
                 "elevation" => h1 + (elevation_difference)*i/sub_pipe_count,
             )
         end
@@ -331,9 +331,9 @@ function _prep_transient_data!(
                 "p_min" => pipe["p_min"],
                 "p_max" => pipe["p_max"],
                 "is_bidirectional" => pipe["is_bidirectional"],
-                "is_si_units" => data["is_si_units"],
-                "is_english_units" => data["is_english_units"],
-                "is_per_unit" => data["is_per_unit"],
+                "si_units" => data["si_units"],
+                "english_units" => data["english_units"],
+                "per_unit" => data["per_unit"],
                 "flow_min" => pipe["flow_min"],
                 "flow_max" => pipe["flow_max"]
             )

--- a/test/data/transient/case6_base_solution.json
+++ b/test/data/transient/case6_base_solution.json
@@ -7,7 +7,7 @@
   "objective": -167.19018814779176,
   "solution": {
     "base_density": 21.717986575066167,
-    "is_per_unit": 1,
+    "per_unit": true,
     "multinetwork": false,
     "base_volume": 5000,
     "compressor": {

--- a/test/data/transient/case6_ls_a_solution.json
+++ b/test/data/transient/case6_ls_a_solution.json
@@ -7,7 +7,7 @@
   "objective": 0.006654090703963705,
   "solution": {
     "base_density": 21.717986575066167,
-    "is_per_unit": 1,
+    "per_unit": true,
     "multinetwork": true,
     "base_volume": 5000,
     "base_length": 5000,

--- a/test/data/transient/case6elevationtr.json
+++ b/test/data/transient/case6elevationtr.json
@@ -7,7 +7,7 @@
   "objective": -18989.191876545374,
   "solution": {
     "base_density": 21.717986575066167,
-    "is_per_unit": 1,
+    "per_unit": true,
     "multinetwork": true,
     "base_volume": 5000,
     "base_length": 5000,

--- a/test/data/transient/transient_time_periodic_storage.json
+++ b/test/data/transient/transient_time_periodic_storage.json
@@ -7,7 +7,7 @@
   "objective": -9220.202571421556,
   "solution": {
     "base_density": 21.717986575066167,
-    "is_per_unit": 1,
+    "per_unit": true,
     "multinetwork": true,
     "base_volume": 5000,
     "base_length": 5000,


### PR DESCRIPTION
find and replace across all files to replace the instances of `is_per_unit = 0` to `per_unit = false`. Also applies to all cases of si units, english units, asserts, etc. 

note, this will break any code that asserts/checks/sets the units within the gasmodels data dict. It is NOT breaking if you just do the normal parse file, solve ogf thing. 

It should probably include a minor version bump. 

Closes issue #221 