### PR TITLE
new matgas writer

### DIFF
--- a/src/GasModels.jl
+++ b/src/GasModels.jl
@@ -46,6 +46,14 @@ module GasModels
     const acceleration_gravity = 9.81
     const gm_it_name = "gm"
     const gm_it_sym = Symbol(gm_it_name)
+    const _PKG_ROOT = dirname(dirname(pathof(GasModels)))
+    const CASE6PATH = joinpath(
+        _PKG_ROOT,
+        "test",
+        "data",
+        "matgas",
+        "case-6.m",
+    )
 
     include("io/json.jl")
     include("io/common.jl")

--- a/src/io/matgas.jl
+++ b/src/io/matgas.jl
@@ -1180,7 +1180,20 @@ function _present_columns(
     return [name for name in canonical_names if name in present]
 end
 
-_present_extra_columns(rows::Vector{Dict{String,Any}}, extra_cols::Vector{String}) = extra_cols
+function _present_extra_columns(rows::Vector{Dict{String,Any}}, extra_cols::Vector{String})
+    present = Set{String}()
+
+    for row in rows
+        for col in extra_cols
+            val = _row_get(row, col)
+            if !(val === nothing || val isa Missing)
+                push!(present, col)
+            end
+        end
+    end
+
+    return [col for col in extra_cols if col in present]
+end
 
 # ------------------------------------------------------------------
 # cell formatting

--- a/src/io/matgas.jl
+++ b/src/io/matgas.jl
@@ -955,14 +955,6 @@ const _mg_extra_data_columns = Dict{String,Vector{String}}(
 """
     write_matgas(filename::String, gm_data::Dict{String,<:Any})
     write_matgas(io::IO, gm_data::Dict{String,<:Any})
-
-Write a GasModels data dictionary to a matgas `.m` file.
-
-Design goals:
-- header-driven output using actual present fields
-- canonical ordering when fields exist
-- no column-shift bugs when some fields are removed
-- strings quoted, floats compactly formatted, missing -> NaN
 """
 function write_matgas(filename::String, gm_data::Dict{String,<:Any})
     open(filename, "w") do io
@@ -1112,8 +1104,8 @@ function _normalize_rows(rows::AbstractDict, section_name::String)
 
     out = Vector{Dict{String,Any}}()
     sizehint!(out, length(vals))
-    for row in vals
-        push!(out, _normalize_row(row, section_name))
+    for xrow in vals
+        push!(out, _normalize_row(xrow, section_name))
     end
     return out
 end
@@ -1124,7 +1116,7 @@ function _normalize_row(row::AbstractDict, section_name::String)
     for (k, v) in row
         ks = String(k)
 
-        # internal bookkeeping / non-matgas fields → skip
+        # internal bookkeeping
         if ks in (
             "si_units", "english_units", "per_unit",
             "is_si_units", "is_english_units", "is_per_unit"
@@ -1132,7 +1124,7 @@ function _normalize_row(row::AbstractDict, section_name::String)
             continue
         end
 
-        # don't write internal index directly
+        # don't write index directly
         if ks == "index"
             continue
         end
@@ -1176,7 +1168,7 @@ function _present_columns(
         end
     end
 
-    # Only emit columns that are both canonical and present
+    # only write canonical and present columns
     return [name for name in canonical_names if name in present]
 end
 

--- a/src/io/matgas.jl
+++ b/src/io/matgas.jl
@@ -956,13 +956,14 @@ const _mg_extra_data_columns = Dict{String,Vector{String}}(
     write_matgas(filename::String, gm_data::Dict{String,<:Any})
     write_matgas(io::IO, gm_data::Dict{String,<:Any})
 """
-function write_matgas(filename::String, gm_data::Dict{String,<:Any})
+function write_matgas(filename::String, gm_data::Dict{String,<:Any}, precision::Int)
+    #precision is number of digits that floats will be written in
     open(filename, "w") do io
-        write_matgas(io, gm_data)
+        write_matgas(io, gm_data, precision)
     end
 end
 
-function write_matgas(io::IO, gm_data::Dict{String,<:Any})
+function write_matgas(io::IO, gm_data::Dict{String,<:Any}, precison::Int=6)
     make_si_units!(gm_data)
     case_name = get(gm_data, "name", "gas_network")
     func_name = _sanitize_matlab_identifier(String(case_name))
@@ -971,37 +972,37 @@ function write_matgas(io::IO, gm_data::Dict{String,<:Any})
     println(io)
 
     # ---- scalar metadata ----
-    _write_scalar_if_present(io, "mgc.version", get(gm_data, "source_version", v"0.0.0"))
-    _write_scalar_if_present(io, "mgc.name", get(gm_data, "name", func_name))
-    _write_scalar_if_present(io, "mgc.gas_specific_gravity", gm_data["gas_specific_gravity"])
-    _write_scalar_if_present(io, "mgc.specific_heat_capacity_ratio", gm_data["specific_heat_capacity_ratio"])
-    _write_scalar_if_present(io, "mgc.temperature", gm_data["temperature"])
-    _write_scalar_if_present(io, "mgc.sound_speed", get(gm_data, "sound_speed", nothing))
-    _write_scalar_if_present(io, "mgc.compressibility_factor", gm_data["compressibility_factor"])
-    _write_scalar_if_present(io, "mgc.R", get(gm_data, "R", nothing))
-    _write_scalar_if_present(io, "mgc.gas_molar_mass", get(gm_data, "gas_molar_mass", nothing))
-    _write_scalar_if_present(io, "mgc.base_pressure", get(gm_data, "base_pressure", nothing))
-    _write_scalar_if_present(io, "mgc.base_length", get(gm_data, "base_length", nothing))
-    _write_scalar_if_present(io, "mgc.units", gm_data["units"])
-    _write_scalar_if_present(io, "mgc.per_unit", get(gm_data, "per_unit", nothing))
-    _write_scalar_if_present(io, "mgc.economic_weighting", get(gm_data, "economic_weighting", nothing))
+    _write_scalar_if_present(io, "mgc.version", get(gm_data, "source_version", v"0.0.0"), precision)
+    _write_scalar_if_present(io, "mgc.name", get(gm_data, "name", func_name), precision)
+    _write_scalar_if_present(io, "mgc.gas_specific_gravity", gm_data["gas_specific_gravity"], precision)
+    _write_scalar_if_present(io, "mgc.specific_heat_capacity_ratio", gm_data["specific_heat_capacity_ratio"], precision)
+    _write_scalar_if_present(io, "mgc.temperature", gm_data["temperature"], precision)
+    _write_scalar_if_present(io, "mgc.sound_speed", get(gm_data, "sound_speed", nothing), precision)
+    _write_scalar_if_present(io, "mgc.compressibility_factor", gm_data["compressibility_factor"], precision)
+    _write_scalar_if_present(io, "mgc.R", get(gm_data, "R", nothing), precision)
+    _write_scalar_if_present(io, "mgc.gas_molar_mass", get(gm_data, "gas_molar_mass", nothing), precision)
+    _write_scalar_if_present(io, "mgc.base_pressure", get(gm_data, "base_pressure", nothing), precision)
+    _write_scalar_if_present(io, "mgc.base_length", get(gm_data, "base_length", nothing), precision)
+    _write_scalar_if_present(io, "mgc.units", gm_data["units"], precision)
+    _write_scalar_if_present(io, "mgc.per_unit", get(gm_data, "per_unit", nothing), precision)
+    _write_scalar_if_present(io, "mgc.economic_weighting", get(gm_data, "economic_weighting", nothing), precision)
     println(io)
 
     # ---- tabular sections ----
-    _write_section_if_present(io, "sources", get(gm_data, "sources", nothing), _mg_sources_columns)
-    _write_section_if_present(io, "junction", get(gm_data, "junction", nothing), _mg_junction_columns)
-    _write_section_if_present(io, "pipe", get(gm_data, "pipe", nothing), _mg_pipe_columns)
-    _write_section_if_present(io, "ne_pipe", get(gm_data, "ne_pipe", nothing), _mg_ne_pipe_columns)
-    _write_section_if_present(io, "compressor", get(gm_data, "compressor", nothing), _mg_compressor_columns)
-    _write_section_if_present(io, "ne_compressor", get(gm_data, "ne_compressor", nothing), _mg_ne_compressor_columns)
-    _write_section_if_present(io, "transfer", get(gm_data, "transfer", nothing), _mg_transfer_columns)
-    _write_section_if_present(io, "receipt", get(gm_data, "receipt", nothing), _mg_receipt_columns)
-    _write_section_if_present(io, "delivery", get(gm_data, "delivery", nothing), _mg_delivery_columns)
-    _write_section_if_present(io, "short_pipe", get(gm_data, "short_pipe", nothing), _mg_short_pipe_columns)
-    _write_section_if_present(io, "resistor", get(gm_data, "resistor", nothing), _mg_resistor_columns)
-    _write_section_if_present(io, "regulator", get(gm_data, "regulator", nothing), _mg_regulator_columns)
-    _write_section_if_present(io, "valve", get(gm_data, "valve", nothing), _mg_valve_columns)
-    _write_section_if_present(io, "storage", get(gm_data, "storage", nothing), _mg_storage_columns)
+    _write_section_if_present(io, "sources", get(gm_data, "sources", nothing), _mg_sources_columns, precision)
+    _write_section_if_present(io, "junction", get(gm_data, "junction", nothing), _mg_junction_columns, precision)
+    _write_section_if_present(io, "pipe", get(gm_data, "pipe", nothing), _mg_pipe_columns, precision)
+    _write_section_if_present(io, "ne_pipe", get(gm_data, "ne_pipe", nothing), _mg_ne_pipe_columns, precision)
+    _write_section_if_present(io, "compressor", get(gm_data, "compressor", nothing), _mg_compressor_columns, precision)
+    _write_section_if_present(io, "ne_compressor", get(gm_data, "ne_compressor", nothing), _mg_ne_compressor_columns, precision)
+    _write_section_if_present(io, "transfer", get(gm_data, "transfer", nothing), _mg_transfer_columns, precision)
+    _write_section_if_present(io, "receipt", get(gm_data, "receipt", nothing), _mg_receipt_columns, precision)
+    _write_section_if_present(io, "delivery", get(gm_data, "delivery", nothing), _mg_delivery_columns, precision)
+    _write_section_if_present(io, "short_pipe", get(gm_data, "short_pipe", nothing), _mg_short_pipe_columns, precision)
+    _write_section_if_present(io, "resistor", get(gm_data, "resistor", nothing), _mg_resistor_columns, precision)
+    _write_section_if_present(io, "regulator", get(gm_data, "regulator", nothing), _mg_regulator_columns, precision)
+    _write_section_if_present(io, "valve", get(gm_data, "valve", nothing), _mg_valve_columns, precision)
+    _write_section_if_present(io, "storage", get(gm_data, "storage", nothing), _mg_storage_columns, precision)
 end
 
 
@@ -1009,12 +1010,12 @@ end
 # scalar writers
 # ------------------------------------------------------------------
 
-function _write_scalar_if_present(io::IO, lhs::String, value)
+function _write_scalar_if_present(io::IO, lhs::String, value, precision::Int)
     value === nothing && return
-    println(io, lhs, " = ", _format_matgas_scalar(value), ";")
+    println(io, lhs, " = ", _format_matgas_scalar(value, precision), ";")
 end
 
-function _format_matgas_scalar(x)
+function _format_matgas_scalar(x, precision::Int)
     if x isa VersionNumber
         return "'" * string(x) * "'"
     elseif x isa AbstractString || x isa SubString{String}
@@ -1024,7 +1025,7 @@ function _format_matgas_scalar(x)
     elseif x isa Integer
         return string(x)
     elseif x isa AbstractFloat
-        return isnan(x) ? "NaN" : _format_float(x)
+        return isnan(x) ? "NaN" : _format_float(x, precision)
     else
         return "'" * _escape_matgas_string(string(x)) * "'"
     end
@@ -1035,7 +1036,7 @@ end
 # section writers
 # ------------------------------------------------------------------
 
-function _write_section_if_present(io::IO, section_name::String, rows, canonical_cols::Vector{Tuple{String,Type}})
+function _write_section_if_present(io::IO, section_name::String, rows, canonical_cols::Vector{Tuple{String,Type}}, precision::Int=6)
     rows === nothing && return
 
     row_dicts = _normalize_rows(rows, section_name)
@@ -1071,7 +1072,7 @@ function _write_table(io::IO, table_name::String, row_dicts::Vector{Dict{String,
     println(io, "mgc.", table_name, " = [")
 
     for row in row_dicts
-        vals = [_format_matgas_cell(_row_get(row, col)) for col in cols]
+        vals = [_format_matgas_cell(_row_get(row, col), precision) for col in cols]
         println(io, join(vals, "\t"))
     end
 
@@ -1198,7 +1199,7 @@ end
 # cell formatting
 # ------------------------------------------------------------------
 
-function _format_matgas_cell(x)
+function _format_matgas_cell(x, precision::Int)
     if x === nothing || x isa Missing
         return "''"
     elseif x isa Bool
@@ -1206,7 +1207,7 @@ function _format_matgas_cell(x)
     elseif x isa Integer
         return string(x)
     elseif x isa AbstractFloat
-        return isnan(x) ? "''" : _format_float(x)
+        return isnan(x) ? "''" : _format_float(x, precision)
     elseif x isa AbstractString || x isa SubString{String}
         return "'" * _escape_matgas_string(String(x)) * "'"
     else
@@ -1214,7 +1215,7 @@ function _format_matgas_cell(x)
     end
 end
 
-_format_float(x::AbstractFloat) = Printf.@sprintf("%.5g", x)
+_format_float(x::AbstractFloat, precision::Int=6) = Printf.@sprintf("%.$(string(precision))g", x)
 
 _escape_matgas_string(s::String) = replace(s, "'" => "''")
 

--- a/src/io/matgas.jl
+++ b/src/io/matgas.jl
@@ -1215,7 +1215,7 @@ function _format_matgas_cell(x, precision::Int)
     end
 end
 
-_format_float(x::AbstractFloat, precision::Int=6) = Printf.@sprintf("%.$(string(precision))g", x)
+_format_float(x::AbstractFloat, precision::Int=6) = Printf.format(Printf.Format("%.$(precision)g"), x)
 
 _escape_matgas_string(s::String) = replace(s, "'" => "''")
 

--- a/src/io/matgas.jl
+++ b/src/io/matgas.jl
@@ -942,167 +942,273 @@ function _validate_schema(data)
     end
 end
 
-"write to matgas"
-function _gasmodels_to_matgas_string(
-        data::Dict{String,Any};
-        units::String = "si",
-        include_extended::Bool = false,
-    )::String
+const _mg_extra_data_columns = Dict{String,Vector{String}}(
+    "junction"   => ["coordinates", "elevation"],
+    "pipe"       => ["coordinates"],
+    "compressor" => ["coordinates", "mapping_id"],
+    "transfer"   => ["coordinates", "wmg_location_role_id", "mapping_id", "market_id"],
+    "receipt"    => ["coordinates", "wmg_location_role_id", "mapping_id", "market_id"],
+    "delivery"   => ["coordinates", "wmg_location_role_id", "mapping_id", "market_id"],
+)
 
-    (data["is_english_units"] == true) && (units = "usc")
-    lines = ["function mgc = $(replace(data["name"], " " => "_"))", ""]
 
-    _validate_schema(data)
-    for headervalue in vcat(_matlab_global_params_order_optional, _matlab_global_params_order_required)
-        #keyerror in the dict catches this anyway, just including the loop to make it more explicit
-        @assert haskey(data, headervalue) "missing header information: add $headervalue to case (case['$headervalue'] = something)"
+"""
+    write_matgas(filename::String, gm_data::Dict{String,<:Any})
+    write_matgas(io::IO, gm_data::Dict{String,<:Any})
+
+Write a GasModels data dictionary to a matgas `.m` file.
+
+Design goals:
+- header-driven output using actual present fields
+- canonical ordering when fields exist
+- no column-shift bugs when some fields are removed
+- strings quoted, floats compactly formatted, missing -> NaN
+"""
+function write_matgas(filename::String, gm_data::Dict{String,<:Any})
+    open(filename, "w") do io
+        write_matgas(io, gm_data)
     end
-
-    for param in _matlab_global_params_order_required
-        line = isa(data[param], Float64) ?
-            Printf.@sprintf("mgc.%s = %.12g;", param, data[param]) :
-            "mgc.$(param) = $(data[param]);"
-        haskey(_units[units], param) && (line *= "  % $(_units[units][param])")
-        push!(lines, line)
-    end
-    pipeline_name = data["pipeline_name"]
-    push!(lines, "mgc.units = '$units';", "")
-    push!(lines, "mgc.pipeline_name = '$pipeline_name';", "")
-
-    for param in _matlab_global_params_order_optional
-        line = isa(data[param], Float64) ?
-            Printf.@sprintf("mgc.%s = %.12g;", param, data[param]) :
-            "mgc.$(param) = $(data[param]);"
-        haskey(_units[units], param) && (line *= "  % $(_units[units][param])")
-        push!(lines, line)
-    end
-    push!(lines, "")
-
-    #dict/vector helper
-    _entry(container, i) = container isa AbstractDict ? container["$i"] : container[i]
-
-    # ------------------------------------------------------------------------
-    for data_type in _matlab_data_order
-        if haskey(data, data_type)
-            push!(lines, "%% $data_type data")
-
-            fields_header = String[]
-            idxs = collect(eachindex(data[data_type]))
-            if !isempty(idxs)
-                first_id = idxs[1]
-                first_entry = _entry(data[data_type], first_id)
-                for field in _matlab_field_order[data_type]
-                    haskey(first_entry, field) && push!(fields_header, field)
-                end
-            end
-            push!(lines, "% $(join(fields_header, "\t"))")
-
-            # write the matrix
-            push!(lines, "mgc.$data_type = [")
-            if !isempty(idxs)
-                for i in sort(idxs)
-                    entry = _entry(data[data_type], i)
-                    entries = String[]
-                    for field in fields_header
-                        if haskey(entry, field)
-                            val = entry[field]
-                            if isa(val, Union{String,SubString{String}})
-                                push!(entries, "\'$(val)\'")
-                            elseif isa(val, Float64)
-                                push!(entries, Printf.@sprintf("%.12g", val))
-                            else
-                                push!(entries, "$(val)")
-                            end
-                        else
-                            # special handling for the optional edi_id column
-                            field == "edi_id" ? push!(entries, "0") :
-                                Memento.error(_LOGGER,
-                                    string("$(data_type) $(i) is missing field $(field)"))
-                        end
-                    end
-                    push!(lines, "$(join(entries, "\t"))")
-                end
-            end
-            push!(lines, "];\n")
-        end
-    end
-
-    # ------------------------------------------------------------------------
-    if include_extended
-        for data_type in _matlab_data_order
-            if haskey(data, data_type)
-                all_ext_cols = Set([
-                    col for item in values(data[data_type])
-                    for col in keys(item) if !(col in _matlab_field_order[data_type])
-                ])
-                common_ext_cols = [
-                    col for col in all_ext_cols
-                    if all(col in keys(item) for item in values(data[data_type]))
-                ]
-
-                if !isempty(common_ext_cols)
-                    push!(lines, "%% $data_type data (extended)")
-                    push!(lines, "%column_names% $(join(common_ext_cols, "\t"))")
-                    push!(lines, "mgc.$(data_type)_data = [")
-
-                    for i in sort(collect(eachindex(data[data_type])))
-                        row = [
-                            data[data_type][_key(i)][col]   # `_key` converts i → string key when needed
-                            for col in sort(common_ext_cols)
-                        ]
-                        push!(lines, "\t$(join(row, "\t"))")
-                    end
-                    push!(lines, "];\n")
-                end
-            end
-        end
-    end
-
-    push!(lines, "end\n")
-    return join(lines, "\n")
 end
 
-# ------------------------------------------------------------------------
-_key(i) = i isa Integer ? string(i) : i
+function write_matgas(io::IO, gm_data::Dict{String,<:Any})
+    case_name = get(gm_data, "name", "gas_network")
+    func_name = _sanitize_matlab_identifier(String(case_name))
+
+    println(io, "function mgc = ", func_name)
+    println(io)
+
+    # ---- scalar metadata ----
+    _write_scalar_if_present(io, "mgc.version", get(gm_data, "source_version", v"0.0.0"))
+    _write_scalar_if_present(io, "mgc.name", get(gm_data, "name", func_name))
+    _write_scalar_if_present(io, "mgc.gas_specific_gravity", gm_data["gas_specific_gravity"])
+    _write_scalar_if_present(io, "mgc.specific_heat_capacity_ratio", gm_data["specific_heat_capacity_ratio"])
+    _write_scalar_if_present(io, "mgc.temperature", gm_data["temperature"])
+    _write_scalar_if_present(io, "mgc.sound_speed", get(gm_data, "sound_speed", nothing))
+    _write_scalar_if_present(io, "mgc.compressibility_factor", gm_data["compressibility_factor"])
+    _write_scalar_if_present(io, "mgc.R", get(gm_data, "R", nothing))
+    _write_scalar_if_present(io, "mgc.gas_molar_mass", get(gm_data, "gas_molar_mass", nothing))
+    _write_scalar_if_present(io, "mgc.base_pressure", get(gm_data, "base_pressure", nothing))
+    _write_scalar_if_present(io, "mgc.base_length", get(gm_data, "base_length", nothing))
+    _write_scalar_if_present(io, "mgc.units", gm_data["units"])
+    _write_scalar_if_present(io, "mgc.per_unit", get(gm_data, "per_unit", nothing))
+    _write_scalar_if_present(io, "mgc.economic_weighting", get(gm_data, "economic_weighting", nothing))
+    println(io)
+
+    # ---- tabular sections ----
+    _write_section_if_present(io, "sources", get(gm_data, "sources", nothing), _mg_sources_columns)
+    _write_section_if_present(io, "junction", get(gm_data, "junction", nothing), _mg_junction_columns)
+    _write_section_if_present(io, "pipe", get(gm_data, "pipe", nothing), _mg_pipe_columns)
+    _write_section_if_present(io, "compressor", get(gm_data, "compressor", nothing), _mg_compressor_columns)
+    _write_section_if_present(io, "receipt", get(gm_data, "receipt", nothing), _mg_receipt_columns)
+    _write_section_if_present(io, "delivery", get(gm_data, "delivery", nothing), _mg_delivery_columns)
+    _write_section_if_present(io, "transfer", get(gm_data, "transfer", nothing), _mg_transfer_columns)
+    _write_section_if_present(io, "short_pipe", get(gm_data, "short_pipe", nothing), _mg_short_pipe_columns)
+    _write_section_if_present(io, "resistor", get(gm_data, "resistor", nothing), _mg_resistor_columns)
+    _write_section_if_present(io, "regulator", get(gm_data, "regulator", nothing), _mg_regulator_columns)
+    _write_section_if_present(io, "valve", get(gm_data, "valve", nothing), _mg_valve_columns)
+    _write_section_if_present(io, "storage", get(gm_data, "storage", nothing), _mg_storage_columns)
+    _write_section_if_present(io, "ne_pipe", get(gm_data, "ne_pipe", nothing), _mg_ne_pipe_columns)
+    _write_section_if_present(io, "ne_compressor", get(gm_data, "ne_compressor", nothing), _mg_ne_compressor_columns)
+end
 
 
-"writes data structure to matlab format"
-function write_matgas!(
-    data::Dict{String,Any},
-    fileout::String;
-    units::String = "si",
-    include_extended::Bool = false,
+# ------------------------------------------------------------------
+# scalar writers
+# ------------------------------------------------------------------
+
+function _write_scalar_if_present(io::IO, lhs::String, value)
+    value === nothing && return
+    println(io, lhs, " = ", _format_matgas_scalar(value), ";")
+end
+
+function _format_matgas_scalar(x)
+    if x isa VersionNumber
+        return "'" * string(x) * "'"
+    elseif x isa AbstractString || x isa SubString{String}
+        return "'" * _escape_matgas_string(String(x)) * "'"
+    elseif x isa Bool
+        return x ? "1" : "0"
+    elseif x isa Integer
+        return string(x)
+    elseif x isa AbstractFloat
+        return isnan(x) ? "NaN" : _format_float(x)
+    else
+        return "'" * _escape_matgas_string(string(x)) * "'"
+    end
+end
+
+
+# ------------------------------------------------------------------
+# section writers
+# ------------------------------------------------------------------
+
+function _write_section_if_present(io::IO, section_name::String, rows, canonical_cols::Vector{Tuple{String,Type}})
+    rows === nothing && return
+    isempty(rows) && return
+
+    row_dicts = _normalize_rows(rows, section_name)
+
+    # main section: exclude extra-data-only columns
+    extra_cols = get(_mg_extra_data_columns, section_name, String[])
+    main_cols = _present_columns(row_dicts, canonical_cols; exclude=Set(extra_cols))
+
+    if !isempty(main_cols)
+        _write_table(io, section_name, row_dicts, main_cols)
+    end
+
+    # optional *_data section
+    if haskey(_mg_extra_data_columns, section_name)
+        data_cols = _present_extra_columns(row_dicts, _mg_extra_data_columns[section_name])
+
+        if !isempty(data_cols)
+            _write_table(io, section_name * "_data", row_dicts, data_cols)
+        end
+    end
+end
+
+function _write_table(io::IO, table_name::String, row_dicts::Vector{Dict{String,Any}}, cols::Vector{String})
+    println(io, "%% ", table_name)
+    println(io, "%column_names% ", join(cols, " "))
+    println(io, "mgc.", table_name, " = [")
+
+    for row in row_dicts
+        vals = [_format_matgas_cell(_row_get(row, col)) for col in cols]
+        println(io, join(vals, "\t"))
+    end
+
+    println(io, "];")
+    println(io)
+end
+
+# ------------------------------------------------------------------
+# row normalization
+# ------------------------------------------------------------------
+
+function _normalize_rows(rows::AbstractVector, section_name::String)
+    out = Vector{Dict{String,Any}}()
+    sizehint!(out, length(rows))
+    for row in rows
+        push!(out, _normalize_row(row, section_name))
+    end
+    return out
+end
+
+function _normalize_rows(rows::AbstractDict, section_name::String)
+    out = Vector{Dict{String,Any}}()
+    sizehint!(out, length(rows))
+    for row in values(rows)
+        push!(out, _normalize_row(row, section_name))
+    end
+    return out
+end
+
+function _normalize_row(row::AbstractDict, section_name::String)
+    out = Dict{String,Any}()
+
+    for (k, v) in row
+        ks = String(k)
+
+        # internal bookkeeping fields should never be written as table columns
+        if ks in ("si_units", "english_units", "per_unit")
+            continue
+        end
+
+        # don't write internal index directly; map to id below if needed
+        if ks == "index"
+            continue
+        end
+
+        out[ks] = v
+    end
+
+    if !haskey(out, "id")
+        if haskey(row, "id")
+            out["id"] = row["id"]
+        elseif haskey(row, :id)
+            out["id"] = row[:id]
+        elseif haskey(row, "index")
+            out["id"] = row["index"]
+        elseif haskey(row, :index)
+            out["id"] = row[:index]
+        end
+    end
+
+    return out
+end
+# ------------------------------------------------------------------
+# column selection
+# ------------------------------------------------------------------
+
+function _present_columns(
+    rows::Vector{Dict{String,Any}},
+    canonical_cols::Vector{Tuple{String,Type}};
+    exclude::Set{String}=Set{String}()
 )
-    if haskey(data, "original_pipe")
-        data["new_pipe"] = deepcopy(data["pipe"])
-        data["pipe"] = deepcopy(data["original_pipe"])
-        delete!(data, "original_pipe")
-    end
-    if haskey(data, "original_junction")
-        data["new_junction"] = deepcopy(data["junction"])
-        data["junction"] = deepcopy(data["original_junction"])
-        delete!(data, "original_junction")
+    canonical_names = [name for (name, _) in canonical_cols if !(name in exclude)]
+    present = Set{String}()
+
+    for row in rows
+        for k in keys(row)
+            if !(k in exclude)
+                push!(present, k)
+            end
+        end
     end
 
-    open(fileout, "w") do f
-        write(
-            f,
-            _gasmodels_to_matgas_string(
-                data;
-                units = units,
-                include_extended = include_extended,
-            ),
-        )
-    end
+    ordered = [name for name in canonical_names if name in present]
+    extras = sort([name for name in present if !(name in canonical_names)])
 
-    if haskey(data, "new_pipe")
-        data["original_pipe"] = deepcopy(data["pipe"])
-        data["pipe"] = deepcopy(data["new_pipe"])
-        delete!(data, "new_pipe")
+    return vcat(ordered, extras)
+end
+
+_present_extra_columns(rows::Vector{Dict{String,Any}}, extra_cols::Vector{String}) = extra_cols
+
+# ------------------------------------------------------------------
+# cell formatting
+# ------------------------------------------------------------------
+
+function _format_matgas_cell(x)
+    if x === nothing || x isa Missing
+        return "''"
+    elseif x isa Bool
+        return x ? "1" : "0"
+    elseif x isa Integer
+        return string(x)
+    elseif x isa AbstractFloat
+        return isnan(x) ? "''" : _format_float(x)
+    elseif x isa AbstractString || x isa SubString{String}
+        return "'" * _escape_matgas_string(String(x)) * "'"
+    else
+        return "'" * _escape_matgas_string(string(x)) * "'"
     end
-    if haskey(data, "new_junction")
-        data["original_junction"] = deepcopy(data["junction"])
-        data["junction"] = deepcopy(data["new_junction"])
-        delete!(data, "new_junction")
+end
+
+_format_float(x::AbstractFloat) = Printf.@sprintf("%.4g", x)
+
+_escape_matgas_string(s::String) = replace(s, "'" => "''")
+
+
+# ------------------------------------------------------------------
+# lookup helpers
+# ------------------------------------------------------------------
+
+function _row_get(row::AbstractDict, col::String)
+    if haskey(row, col)
+        return row[col]
+    elseif haskey(row, Symbol(col))
+        return row[Symbol(col)]
+    else
+        return nothing
+    end
+end
+
+function _sanitize_matlab_identifier(s::String)
+    s2 = replace(s, r"[^A-Za-z0-9_]" => "_")
+    if isempty(s2)
+        return "gas_network"
+    elseif occursin(r"^[0-9]", s2)
+        return "case_" * s2
+    else
+        return s2
     end
 end

--- a/src/io/matgas.jl
+++ b/src/io/matgas.jl
@@ -1020,7 +1020,7 @@ function _format_matgas_scalar(x)
     elseif x isa AbstractString || x isa SubString{String}
         return "'" * _escape_matgas_string(String(x)) * "'"
     elseif x isa Bool
-        return x ? "1" : "0"
+        return x ? "true" : "false"
     elseif x isa Integer
         return string(x)
     elseif x isa AbstractFloat

--- a/src/io/matgas.jl
+++ b/src/io/matgas.jl
@@ -964,6 +964,9 @@ end
 
 function write_matgas(io::IO, gm_data::Dict{String,<:Any})
     make_si_units!(gm_data)
+    if haskey(gm_data, "ne_compressor") || haskey(gm_data, "ne_pipe")
+        throw(ArgumentError("write_matgas does not currently support Network Expansion cases"))
+    end
     case_name = get(gm_data, "name", "gas_network")
     func_name = _sanitize_matlab_identifier(String(case_name))
 
@@ -992,9 +995,9 @@ function write_matgas(io::IO, gm_data::Dict{String,<:Any})
     _write_section_if_present(io, "junction", get(gm_data, "junction", nothing), _mg_junction_columns)
     _write_section_if_present(io, "pipe", get(gm_data, "pipe", nothing), _mg_pipe_columns)
     _write_section_if_present(io, "compressor", get(gm_data, "compressor", nothing), _mg_compressor_columns)
+    _write_section_if_present(io, "transfer", get(gm_data, "transfer", nothing), _mg_transfer_columns)
     _write_section_if_present(io, "receipt", get(gm_data, "receipt", nothing), _mg_receipt_columns)
     _write_section_if_present(io, "delivery", get(gm_data, "delivery", nothing), _mg_delivery_columns)
-    _write_section_if_present(io, "transfer", get(gm_data, "transfer", nothing), _mg_transfer_columns)
     _write_section_if_present(io, "short_pipe", get(gm_data, "short_pipe", nothing), _mg_short_pipe_columns)
     _write_section_if_present(io, "resistor", get(gm_data, "resistor", nothing), _mg_resistor_columns)
     _write_section_if_present(io, "regulator", get(gm_data, "regulator", nothing), _mg_regulator_columns)
@@ -1020,7 +1023,7 @@ function _format_matgas_scalar(x)
     elseif x isa AbstractString || x isa SubString{String}
         return "'" * _escape_matgas_string(String(x)) * "'"
     elseif x isa Bool
-        return x ? "true" : "false"
+        return x ? "1" : "0"
     elseif x isa Integer
         return string(x)
     elseif x isa AbstractFloat
@@ -1208,7 +1211,7 @@ function _format_matgas_cell(x)
     end
 end
 
-_format_float(x::AbstractFloat) = Printf.@sprintf("%.4g", x)
+_format_float(x::AbstractFloat) = Printf.@sprintf("%.5g", x)
 
 _escape_matgas_string(s::String) = replace(s, "'" => "''")
 

--- a/src/io/matgas.jl
+++ b/src/io/matgas.jl
@@ -964,9 +964,6 @@ end
 
 function write_matgas(io::IO, gm_data::Dict{String,<:Any})
     make_si_units!(gm_data)
-    if haskey(gm_data, "ne_compressor") || haskey(gm_data, "ne_pipe")
-        throw(ArgumentError("write_matgas does not currently support Network Expansion cases"))
-    end
     case_name = get(gm_data, "name", "gas_network")
     func_name = _sanitize_matlab_identifier(String(case_name))
 
@@ -994,7 +991,9 @@ function write_matgas(io::IO, gm_data::Dict{String,<:Any})
     _write_section_if_present(io, "sources", get(gm_data, "sources", nothing), _mg_sources_columns)
     _write_section_if_present(io, "junction", get(gm_data, "junction", nothing), _mg_junction_columns)
     _write_section_if_present(io, "pipe", get(gm_data, "pipe", nothing), _mg_pipe_columns)
+    _write_section_if_present(io, "ne_pipe", get(gm_data, "ne_pipe", nothing), _mg_ne_pipe_columns)
     _write_section_if_present(io, "compressor", get(gm_data, "compressor", nothing), _mg_compressor_columns)
+    _write_section_if_present(io, "ne_compressor", get(gm_data, "ne_compressor", nothing), _mg_ne_compressor_columns)
     _write_section_if_present(io, "transfer", get(gm_data, "transfer", nothing), _mg_transfer_columns)
     _write_section_if_present(io, "receipt", get(gm_data, "receipt", nothing), _mg_receipt_columns)
     _write_section_if_present(io, "delivery", get(gm_data, "delivery", nothing), _mg_delivery_columns)
@@ -1003,8 +1002,6 @@ function write_matgas(io::IO, gm_data::Dict{String,<:Any})
     _write_section_if_present(io, "regulator", get(gm_data, "regulator", nothing), _mg_regulator_columns)
     _write_section_if_present(io, "valve", get(gm_data, "valve", nothing), _mg_valve_columns)
     _write_section_if_present(io, "storage", get(gm_data, "storage", nothing), _mg_storage_columns)
-    _write_section_if_present(io, "ne_pipe", get(gm_data, "ne_pipe", nothing), _mg_ne_pipe_columns)
-    _write_section_if_present(io, "ne_compressor", get(gm_data, "ne_compressor", nothing), _mg_ne_compressor_columns)
 end
 
 
@@ -1040,22 +1037,22 @@ end
 
 function _write_section_if_present(io::IO, section_name::String, rows, canonical_cols::Vector{Tuple{String,Type}})
     rows === nothing && return
-    isempty(rows) && return
 
     row_dicts = _normalize_rows(rows, section_name)
 
-    # main section: exclude extra-data-only columns
     extra_cols = get(_mg_extra_data_columns, section_name, String[])
-    main_cols = _present_columns(row_dicts, canonical_cols; exclude=Set(extra_cols))
 
-    if !isempty(main_cols)
-        _write_table(io, section_name, row_dicts, main_cols)
-    end
+    main_cols =
+        isempty(row_dicts) ?
+        [name for (name, _) in canonical_cols if !(name in Set(extra_cols))] :
+        _present_columns(row_dicts, canonical_cols; exclude=Set(extra_cols))
 
-    # optional *_data section
-    if haskey(_mg_extra_data_columns, section_name)
+    # always write the main section, even if there are no rows
+    _write_table(io, section_name, row_dicts, main_cols)
+
+    # only write *_data if there is actual extra data present
+    if haskey(_mg_extra_data_columns, section_name) && !isempty(row_dicts)
         data_cols = _present_extra_columns(row_dicts, _mg_extra_data_columns[section_name])
-
         if !isempty(data_cols)
             _write_table(io, section_name * "_data", row_dicts, data_cols)
         end
@@ -1064,7 +1061,13 @@ end
 
 function _write_table(io::IO, table_name::String, row_dicts::Vector{Dict{String,Any}}, cols::Vector{String})
     println(io, "%% ", table_name)
-    println(io, "%column_names% ", join(cols, " "))
+
+    if isempty(row_dicts)
+        println(io, "% ", join(cols, " "))
+    else
+        println(io, "%column_names% ", join(cols, " ")) # %column_names% with a blank matrix breaks the IMs parser
+    end
+
     println(io, "mgc.", table_name, " = [")
 
     for row in row_dicts

--- a/src/io/matgas.jl
+++ b/src/io/matgas.jl
@@ -963,6 +963,7 @@ function write_matgas(filename::String, gm_data::Dict{String,<:Any})
 end
 
 function write_matgas(io::IO, gm_data::Dict{String,<:Any})
+    make_si_units!(gm_data)
     case_name = get(gm_data, "name", "gas_network")
     func_name = _sanitize_matlab_identifier(String(case_name))
 
@@ -1195,7 +1196,7 @@ function _format_matgas_cell(x)
     if x === nothing || x isa Missing
         return "''"
     elseif x isa Bool
-        return x ? "1" : "0"
+        return x ? "true" : "false"
     elseif x isa Integer
         return string(x)
     elseif x isa AbstractFloat

--- a/src/io/matgas.jl
+++ b/src/io/matgas.jl
@@ -1094,9 +1094,25 @@ function _normalize_rows(rows::AbstractVector, section_name::String)
 end
 
 function _normalize_rows(rows::AbstractDict, section_name::String)
+    vals = collect(values(rows))
+
+    sort!(vals; by = row -> begin
+        if haskey(row, "id")
+            row["id"]
+        elseif haskey(row, :id)
+            row[:id]
+        elseif haskey(row, "index")
+            row["index"]
+        elseif haskey(row, :index)
+            row[:index]
+        else
+            typemax(Int)
+        end
+    end)
+
     out = Vector{Dict{String,Any}}()
-    sizehint!(out, length(rows))
-    for row in values(rows)
+    sizehint!(out, length(vals))
+    for row in vals
         push!(out, _normalize_row(row, section_name))
     end
     return out
@@ -1108,12 +1124,15 @@ function _normalize_row(row::AbstractDict, section_name::String)
     for (k, v) in row
         ks = String(k)
 
-        # internal bookkeeping fields should never be written as table columns
-        if ks in ("si_units", "english_units", "per_unit")
+        # internal bookkeeping / non-matgas fields → skip
+        if ks in (
+            "si_units", "english_units", "per_unit",
+            "is_si_units", "is_english_units", "is_per_unit"
+        )
             continue
         end
 
-        # don't write internal index directly; map to id below if needed
+        # don't write internal index directly
         if ks == "index"
             continue
         end
@@ -1121,6 +1140,7 @@ function _normalize_row(row::AbstractDict, section_name::String)
         out[ks] = v
     end
 
+    # ensure id exists
     if !haskey(out, "id")
         if haskey(row, "id")
             out["id"] = row["id"]
@@ -1135,6 +1155,7 @@ function _normalize_row(row::AbstractDict, section_name::String)
 
     return out
 end
+
 # ------------------------------------------------------------------
 # column selection
 # ------------------------------------------------------------------
@@ -1155,10 +1176,8 @@ function _present_columns(
         end
     end
 
-    ordered = [name for name in canonical_names if name in present]
-    extras = sort([name for name in present if !(name in canonical_names)])
-
-    return vcat(ordered, extras)
+    # Only emit columns that are both canonical and present
+    return [name for name in canonical_names if name in present]
 end
 
 _present_extra_columns(rows::Vector{Dict{String,Any}}, extra_cols::Vector{String}) = extra_cols

--- a/src/io/matgas.jl
+++ b/src/io/matgas.jl
@@ -1112,24 +1112,30 @@ function _write_section_if_present(io::IO, section_name::String, rows, canonical
         _present_columns(row_dicts, canonical_cols; exclude=Set(extra_cols))
 
     # always write the main section, even if there are no rows
-    _write_table(io, section_name, row_dicts, main_cols)
+    _write_table(io, section_name, row_dicts, main_cols, precision)
 
     # only write *_data if there is actual extra data present
     if haskey(_mg_extra_data_columns, section_name) && !isempty(row_dicts)
         data_cols = _present_extra_columns(row_dicts, _mg_extra_data_columns[section_name])
         if !isempty(data_cols)
-            _write_table(io, section_name * "_data", row_dicts, data_cols)
+            _write_table(io, section_name * "_data", row_dicts, data_cols, precision)
         end
     end
 end
 
-function _write_table(io::IO, table_name::String, row_dicts::Vector{Dict{String,Any}}, cols::Vector{String})
+function _write_table(
+    io::IO,
+    table_name::String,
+    row_dicts::Vector{Dict{String,Any}},
+    cols::Vector{String},
+    precision::Int,
+)
     println(io, "%% ", table_name)
 
     if isempty(row_dicts)
         println(io, "% ", join(cols, " "))
     else
-        println(io, "%column_names% ", join(cols, " ")) # %column_names% with a blank matrix breaks the IMs parser
+        println(io, "%column_names% ", join(cols, " "))
     end
 
     println(io, "mgc.", table_name, " = [")

--- a/src/io/matgas.jl
+++ b/src/io/matgas.jl
@@ -956,14 +956,14 @@ const _mg_extra_data_columns = Dict{String,Vector{String}}(
     write_matgas(filename::String, gm_data::Dict{String,<:Any})
     write_matgas(io::IO, gm_data::Dict{String,<:Any})
 """
-function write_matgas(filename::String, gm_data::Dict{String,<:Any}, precision::Int)
+function write_matgas(filename::String, gm_data::Dict{String,<:Any}, precision::Int=6)
     #precision is number of digits that floats will be written in
     open(filename, "w") do io
         write_matgas(io, gm_data, precision)
     end
 end
 
-function write_matgas(io::IO, gm_data::Dict{String,<:Any}, precison::Int=6)
+function write_matgas(io::IO, gm_data::Dict{String,<:Any}, precision::Int=6)
     make_si_units!(gm_data)
     case_name = get(gm_data, "name", "gas_network")
     func_name = _sanitize_matlab_identifier(String(case_name))

--- a/test/matgaswriter.jl
+++ b/test/matgaswriter.jl
@@ -22,4 +22,4 @@
 end
 
 rm("../test/data/matgas/case-6-mg-writer.m")
-rm("../test/data/matgas/case-6-mg-elevation-mgw.m")
+rm("../test/data/matgas/case-6-elevation-mgw.m")

--- a/test/matgaswriter.jl
+++ b/test/matgaswriter.jl
@@ -1,0 +1,24 @@
+@testset "matgas file I/O" begin
+    @testset "basic file IO" begin
+        case_a = parse_file("../test/data/matgas/case-6.m")
+        res_a = solve_ogf(case_a, WPGasModel, nlp_solver)
+        write_matgas("../test/data/matgas/case-6-mg-writer.m", case_a)
+        @test isfile("../test/data/matgas/case-6-mg-writer.m")
+        case_b = parse_file("../test/data/matgas/case-6-mg-writer.m")
+        res_b = solve_ogf(case_b, WPGasModel, nlp_solver)
+        @test isapprox(res_a["objective"], res_b["objective"], atol = 1e-2)
+        rm("../test/data/matgas/case-6-mg-writer.m")
+    end
+    
+    @testset "case 6 elevation file IO" begin
+        #this should write the elevation/coordinates data to the extra table
+        case_a = parse_file("../test/data/matgas/case-6-elevation.m")
+        res_a = solve_ogf(case_a, WPGasModel, nlp_solver)
+        write_matgas("../test/data/matgas/case-6-elevation-mgw.m", case_a)
+        @test isfile("../test/data/matgas/case-6-elevation-mgw.m")
+        case_b = parse_file("../test/data/matgas/case-6-elevation-mgw.m")
+        res_b = solve_ogf(case_b, WPGasModel, nlp_solver)
+        @test isapprox(res_a["objective"], res_b["objective"], atol = 1e-2)
+        rm("../test/data/matgas/case-6-mg-elevation-mgw.m")
+    end
+end

--- a/test/matgaswriter.jl
+++ b/test/matgaswriter.jl
@@ -7,7 +7,6 @@
         case_b = parse_file("../test/data/matgas/case-6-mg-writer.m")
         res_b = solve_ogf(case_b, WPGasModel, nlp_solver)
         @test isapprox(res_a["objective"], res_b["objective"], atol = 1e-2)
-        rm("../test/data/matgas/case-6-mg-writer.m")
     end
     
     @testset "case 6 elevation file IO" begin
@@ -19,6 +18,8 @@
         case_b = parse_file("../test/data/matgas/case-6-elevation-mgw.m")
         res_b = solve_ogf(case_b, WPGasModel, nlp_solver)
         @test isapprox(res_a["objective"], res_b["objective"], atol = 1e-2)
-        rm("../test/data/matgas/case-6-mg-elevation-mgw.m")
     end
 end
+
+rm("../test/data/matgas/case-6-mg-writer.m")
+rm("../test/data/matgas/case-6-mg-elevation-mgw.m")

--- a/test/matgaswriter.jl
+++ b/test/matgaswriter.jl
@@ -19,7 +19,26 @@
         res_b = solve_ogf(case_b, WPGasModel, nlp_solver)
         @test isapprox(res_a["objective"], res_b["objective"], atol = 1e-2)
     end
+    @testset "case 6 ne file IO" begin
+        case_a = parse_file("../test/data/matgas/case-6-ne.m")
+        write_matgas("../test/data/matgas/case-6-ne-mgw.m", case_a)
+        @test isfile("../test/data/matgas/case-6-ne-mgw.m")
+        case_b = parse_file("../test/data/matgas/case-6-ne-mgw.m")
+
+        @test length(case_a["junction"]) == length(case_b["junction"])
+        @test length(case_a["pipe"]) == length(case_b["pipe"])
+        @test length(case_a["ne_pipe"]) == length(case_b["ne_pipe"])
+        @test length(case_a["compressor"]) == length(case_b["compressor"])
+        @test length(case_a["ne_compressor"]) == length(case_b["ne_compressor"])
+    end
 end
 
-rm("../test/data/matgas/case-6-mg-writer.m")
-rm("../test/data/matgas/case-6-elevation-mgw.m")
+if isfile("../test/data/matgas/case-6-mg-writer.m")
+    rm("../test/data/matgas/case-6-mg-writer.m")
+end
+if isfile("../test/data/matgas/case-6-elevation-mgw.m")
+    rm("../test/data/matgas/case-6-elevation-mgw.m")
+end
+if isfile("../test/data/matgas/case-6-ne-mgw.m")
+    rm("../test/data/matgas/case-6-ne-mgw.m")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,8 @@ nlp_solver = ipopt_solver
 include("common.jl")
 
 @testset "GasModels" begin
+    include("matgaswriter.jl")
+
     include("data.jl")
 
     include("mnw.jl")


### PR DESCRIPTION
a ground-up rewritten version of the matgas writer in gasmodels. this is based off of the python matgas writer that I previously wrote for the NAERM models. Both Kern River and case 6 can both be written, parsed, and solved in Ipopt with no issues. 

closes issue #170 