### PR TITLE
Remove Memento and update base julia version to 1.10 LTS

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,13 +5,13 @@ repo = "https://github.com/lanl-ansi/GasModels.jl.git"
 version = "0.12.0"
 
 [deps]
-
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Dierckx = "39dd38d3-220a-591b-8e3c-4c3a8c710a94"
 InfrastructureModels = "2030c09a-7f63-5d83-885d-db604e0e9cc0"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
-Memento = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+LoggingExtras = "e6f89c97-d47a-5376-807f-9c37f3926c36"
 PolyhedralRelaxations = "2e741578-48fa-11ea-2d62-b52c946f73a0"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
@@ -19,7 +19,6 @@ XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [compat]
-
 Dierckx = "~0.4, ~0.5"
 HiGHS = "~1"
 InfrastructureModels = "~0.7"
@@ -27,11 +26,12 @@ Ipopt = "~1"
 JSON = "~0.21"
 JuMP = "~1.0, 1"
 Juniper = ">= 0.4"
-Memento = "~1.0, ~1.1, ~1.2, ~1.3, ~1.4"
+Logging = "1"
+LoggingExtras = "0.4.9"
 PolyhedralRelaxations = "~0.3"
 XMLDict = "~0.4"
 ZipFile = "~0.10"
-julia = "^1"
+julia = "^1.10"
 
 [extras]
 HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"

--- a/scripts/old_matlab.jl
+++ b/scripts/old_matlab.jl
@@ -161,7 +161,7 @@ function parse_old_m_string(data_string::String)
     if haskey(matlab_data, "mgc.baseP")
         case["baseP"] = matlab_data["mgc.baseP"]
     else
-        Memento.error(_LOGGER, string("no baseP found in .m file.
+        error(string("no baseP found in .m file.
             The file seems to be missing \"mgc.baseP = ...\" \n
             Typical value is a pmin in any of the junction"))
     end
@@ -169,14 +169,14 @@ function parse_old_m_string(data_string::String)
     if haskey(matlab_data, "mgc.baseF")
         case["baseF"] = matlab_data["mgc.baseF"]
     else
-        Memento.error(_LOGGER, string("no baseF found in .m file.
+        error(string("no baseF found in .m file.
             The file seems to be missing \"mgc.baseF = ...\" "))
     end
 
     if haskey(matlab_data, "mgc.per_unit")
         case["per_unit"] = matlab_data["mgc.per_unit"] == 1 ? true : false
     else
-        Memento.error(_LOGGER, string("no per_unit found in .m file.
+        error(string("no per_unit found in .m file.
             The file seems to be missing \"mgc.per_unit = ...\" "))
     end
 
@@ -189,7 +189,7 @@ function parse_old_m_string(data_string::String)
         end
         case["junction"] = junctions
     else
-        Memento.error(_LOGGER, string("no junction table found in .m file.
+        error(string("no junction table found in .m file.
             The file seems to be missing \"mgc.junction = [...];\""))
     end
 
@@ -202,7 +202,7 @@ function parse_old_m_string(data_string::String)
         end
         case["pipe"] = pipes
     else
-        Memento.error(_LOGGER, string("no pipe table found in .m file.
+        error(string("no pipe table found in .m file.
             The file seems to be missing \"mgc.pipe = [...];\""))
     end
 
@@ -228,7 +228,7 @@ function parse_old_m_string(data_string::String)
         end
         case["compressor"] = compressors
     else
-        Memento.error(_LOGGER, string("no compressor table found in .m file.
+        error(string("no compressor table found in .m file.
             The file seems to be missing \"mgc.compressor = [...];\""))
     end
 
@@ -272,7 +272,7 @@ function parse_old_m_string(data_string::String)
         case["junction_name"] = junction_names
 
         if length(case["junction_name"]) != length(case["junction"])
-            Memento.error(_LOGGER, "incorrect .m file, the number of junction names ($(length(case["junction_name"]))) is inconsistent with the number of junctions ($(length(case["junction"]))).\n")
+            error("incorrect .m file, the number of junction names ($(length(case["junction_name"]))) is inconsistent with the number of junctions ($(length(case["junction"]))).\n")
         end
     end
 

--- a/src/GasModels.jl
+++ b/src/GasModels.jl
@@ -6,33 +6,31 @@ module GasModels
 
     import JSON
     import JuMP
-    import Memento
     import Printf
     import Statistics
 
-    using Dates
+    using Dates, Logging, LoggingExtras
     using Dierckx
     using PolyhedralRelaxations
+    
+    include("core/logging.jl")
+    _DEFAULT_LOGGER = Logging.current_logger()
+    _LOGGER = Logging.ConsoleLogger(; meta_formatter=GasModels._gm_metafmt)
+    function __init__()
+        global _DEFAULT_LOGGER = Logging.current_logger()
+        global _LOGGER = Logging.ConsoleLogger(; meta_formatter=GasModels._gm_metafmt)
 
-
-
-    # Create our module level logger (this will get precompiled)
-    const _LOGGER = Memento.getlogger(@__MODULE__)
-
-    # Register the module level logger at runtime so that folks can access the logger via `getlogger(GasModels)`
-    # NOTE: If this line is not included then the precompiled `GasModels.LOGGER` won't be registered at runtime.
-    __init__() = Memento.register(_LOGGER)
-
-    "Suppresses information and warning messages output by GasModels, for fine grained control use the Memento package"
-    function silence()
-        Memento.info(_LOGGER, "Suppressing information and warning messages for the rest of this session.  Use the Memento package for more fine-grained control of logging.")
-        Memento.setlevel!(Memento.getlogger(InfrastructureModels), "error")
-        Memento.setlevel!(Memento.getlogger(GasModels), "error")
+        Logging.global_logger(_LOGGER)
     end
 
-    "alows the user to set the logging level without the need to add Memento"
+    "Suppresses information and warning messages output by GasModels, for fine grained control use the Logging standard library"
+    function silence()
+        silence!()
+    end
+
+    "allows the user to set the logging level without the need to add Logging"
     function logger_config!(level)
-        Memento.config!(Memento.getlogger("GasModels"), level)
+        set_logging_level!(Symbol(uppercase(level[1]) * level[2:end]))
     end
 
     const _gm_global_keys = Set(["gas_specific_gravity", "specific_heat_capacity_ratio",

--- a/src/core/constraint_transient.jl
+++ b/src/core/constraint_transient.jl
@@ -97,7 +97,7 @@ function constraint_compressor_physics(gm::AbstractGasModel, nw::Int, compressor
             _add_constraint!(gm, nw, :compressor_physics_ratios_9, compressor_id, JuMP.@constraint(gm.model,  alpha == alpha_1 + alpha_2 - 1))
             # There is a disjunction, so we have to use a binary variable for this one
         else
-            Memento.error(_LOGGER, "For bidirectional compressor c_ratio_min needs to be <= 1.0 and c_ratio_max needs to be >= 1.0")
+            error("For bidirectional compressor c_ratio_min needs to be <= 1.0 and c_ratio_max needs to be >= 1.0")
         end
         return
     end

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -98,7 +98,7 @@ end
 function _per_unit_data_field_check!(data::Dict{String,Any})
     if get(data, "per_unit", false) == true
         if get(data, "base_pressure", false) == false || get(data, "base_length", false) == false
-            Memento.error(_LOGGER, "data in .m file is in per unit but no base_pressure (in Pa) and base_length (in m) values are provided")
+            error("data in .m file is in per unit but no base_pressure (in Pa) and base_length (in m) values are provided")
         else
             if get(data, "base_density", false) == false
                 data["base_density"] = calc_base_density(data)
@@ -451,7 +451,7 @@ function si_to_pu!(data::Dict{String,<:Any}; id = "0")
     for (component, parameters) in _params_for_unit_conversions
         for (i, comp) in get(gm_nw_data, component, [])
             if !haskey(comp, "per_unit") && !haskey(gm_data, "per_unit")
-                Memento.error(_LOGGER, "the current units of the data/result dictionary unknown")
+                error("the current units of the data/result dictionary unknown")
             end
 
             if !haskey(comp, "per_unit") && haskey(gm_data, "per_unit")
@@ -500,7 +500,7 @@ function pu_to_si!(data::Dict{String,<:Any}; id = "0")
     for (component, parameters) in _params_for_unit_conversions
         for (i, comp) in get(gm_nw_data, component, [])
             if !haskey(comp, "per_unit") && !haskey(gm_data, "per_unit")
-                Memento.error(_LOGGER, "the current units of the data/result dictionary unknown")
+                error("the current units of the data/result dictionary unknown")
             end
 
             if !haskey(comp, "per_unit") && haskey(gm_data, "per_unit")
@@ -547,7 +547,7 @@ function si_to_english!(data::Dict{String,<:Any}; id = "0")
     for (component, parameters) in _params_for_unit_conversions
         for (i, comp) in get(gm_nw_data, component, [])
             if !haskey(comp, "per_unit") && !haskey(gm_data, "per_unit")
-                Memento.error(_LOGGER, "the current units of the data/result dictionary unknown")
+                error("the current units of the data/result dictionary unknown")
             end
 
             if !haskey(comp, "per_unit") && haskey(gm_data, "per_unit")
@@ -594,7 +594,7 @@ function english_to_si!(data::Dict{String,<:Any}; id = "0")
     for (component, parameters) in _params_for_unit_conversions
         for (i, comp) in get(gm_nw_data, component, [])
             if !haskey(comp, "per_unit") && !haskey(gm_data, "per_unit")
-                Memento.error(_LOGGER, "the current units of the data/result dictionary unknown")
+                error("the current units of the data/result dictionary unknown")
             end
 
             if !haskey(comp, "per_unit") && haskey(gm_data, "per_unit")
@@ -757,7 +757,7 @@ function _check_rouge_junction_ids(data::Dict{String,<:Any})
         for (i, table) in get(data, field, [])
             for column_name in get(rouge_junction_id_fields, field, [])
                 if !(table[column_name] in junction_ids)
-                    Memento.error(_LOGGER, "junction_id of $field[$i] does not exist in junction table.")
+                    error("junction_id of $field[$i] does not exist in junction table.")
                 end
             end
         end
@@ -768,7 +768,7 @@ end
 function _check_non_negativity(data::Dict{String, <:Any})
     for field in non_negative_metadata
         if get(data, field, 0.0) < 0.0
-            Memento.error(_LOGGER, "Metadata $field is less than zero.")
+            error("Metadata $field is less than zero.")
         end
     end
 
@@ -776,7 +776,7 @@ function _check_non_negativity(data::Dict{String, <:Any})
         for (i, table) in get(data, field, [])
             for column_name in get(non_negative_data, field, [])
                 if get(table, column_name, 0.0) < 0.0
-                    Memento.error(_LOGGER, "$field[$i][$column_name] is less than zero.")
+                    error("$field[$i][$column_name] is less than zero.")
                 end
             end
         end
@@ -790,7 +790,7 @@ function _check_non_zero(data::Dict{String, <:Any})
         for (i, table) in get(data, field, [])
             for column_name in get(non_negative_data, field, [])
                 if get(table, column_name, 0.0) < 0.0
-                    Memento.error(_LOGGER, "$field[$i][$column_name] is zero.")
+                    error("$field[$i][$column_name] is zero.")
                 end
             end
         end
@@ -807,23 +807,23 @@ end
 "checks validity of global-level parameters"
 function _check_global_parameters(data::Dict{String, <:Any})
     if get(data, "temperature", 273.15) < 260 || get(data, "temperature", 273.15) > 320
-        Memento.warn(_LOGGER, "temperature of $(data["temperature"]) K is unrealistic")
+        @warn ("temperature of $(data["temperature"]) K is unrealistic")
     end
 
     if get(data, "specific_heat_capacity_ratio", 1.4) < 1.2 || get(data, "specific_heat_capacity_ratio", 1.4) > 1.6
-        Memento.warn(_LOGGER, "specific heat capacity ratio of $(data["specific_heat_capacity_ratio"]) is unrealistic")
+        @warn ("specific heat capacity ratio of $(data["specific_heat_capacity_ratio"]) is unrealistic")
     end
 
     if get(data, "gas_specific_gravity", 0.6) < 0.5 || get(data, "gas_specific_gravity", 0.6) > 0.7
-        Memento.warn(_LOGGER, "gas specific gravity $(data["gas_specific_gravity"]) is unrealistic")
+        @warn ("gas specific gravity $(data["gas_specific_gravity"]) is unrealistic")
     end
 
     if get(data, "sound_speed", 355.0) < 300.0 || get(data, "sound_speed", 355.0) > 410.0
-        Memento.warn(_LOGGER, "sound speed of $(data["sound_speed"]) m/s is unrealistic")
+        @warn ("sound speed of $(data["sound_speed"]) m/s is unrealistic")
     end
 
     if get(data, "compressibility_factor", 0.8) < 0.7 || get(data, "compressibility_factor", 0.8) > 1.0
-        Memento.warn(_LOGGER, "compressibility_factor $(data["compressibility_factor"]) is unrealistic")
+        @warn ("compressibility_factor $(data["compressibility_factor"]) is unrealistic")
     end
 end
 
@@ -948,7 +948,7 @@ end
 function _correct_p_mins!(data::Dict{String,Any}; si_value = 1.37e6, english_value = 200.0)
     for (i, junction) in get(data, "junction", [])
         if junction["p_min"] < 0.0
-            Memento.warn(_LOGGER, "junction $i's p_min changed to 1.37E6 Pa (200 PSI) from < 0")
+            @warn ("junction $i's p_min changed to 1.37E6 Pa (200 PSI) from < 0")
             (data["si_units"] == true) && (junction["p_min"] = si_value)
             (data["english_units"] == true) && (junction["p_min"] = english_value)
         end
@@ -956,7 +956,7 @@ function _correct_p_mins!(data::Dict{String,Any}; si_value = 1.37e6, english_val
 
     for (i, pipe) in get(data, "pipe", [])
         if pipe["p_min"] < 0.0
-            Memento.warn(_LOGGER, "pipe $i's p_min changed to 1.37E6 Pa (200 PSI) from < 0")
+            @warn ("pipe $i's p_min changed to 1.37E6 Pa (200 PSI) from < 0")
             (data["si_units"] == true) && (pipe["p_min"] = si_value)
             (data["english_units"] == true) && (pipe["p_min"] = english_value)
         end
@@ -964,13 +964,13 @@ function _correct_p_mins!(data::Dict{String,Any}; si_value = 1.37e6, english_val
 
     for (i, compressor) in get(data, "compressor", [])
         if compressor["inlet_p_min"] < 0
-            Memento.warn(_LOGGER, "compressor $i's inlet_p_min changed to 1.37E6 Pa (200 PSI) from < 0")
+            @warn ("compressor $i's inlet_p_min changed to 1.37E6 Pa (200 PSI) from < 0")
             (data["si_units"] == true) && (compressor["inlet_p_min"] = si_value)
             (data["english_units"] == true) && (compressor["inlet_p_min"] = english_value)
         end
 
         if compressor["outlet_p_min"] < 0
-            Memento.warn(_LOGGER, "compressor $i's outlet_p_min changed to 1.37E6 Pa (200 PSI) from < 0")
+            @warn ("compressor $i's outlet_p_min changed to 1.37E6 Pa (200 PSI) from < 0")
             (data["si_units"] == true) && (compressor["outlet_p_min"] = si_value)
             (data["english_units"] == true) && (compressor["outlet_p_min"] = english_value)
         end
@@ -1084,7 +1084,7 @@ function _check_connectivity(data::Dict{String,<:Any})
             for junc_key in _gm_junction_keys
                 if haskey(comp, junc_key)
                     if !(comp[junc_key] in junc_ids)
-                        Memento.warn(_LOGGER, "$junc_key $(comp[junc_key]) in $comp_type $i is not defined")
+                        @warn ("$junc_key $(comp[junc_key]) in $comp_type $i is not defined")
                     end
                 end
             end
@@ -1102,7 +1102,7 @@ end
 "checks that active components are not connected to inactive buses, otherwise prints warnings"
 function _check_status(data::Dict{String,<:Any})
     if _IM.ismultinetwork(data)
-        Memento.error(_LOGGER, "check_status does not yet support multinetwork data")
+        error("check_status does not yet support multinetwork data")
     end
 
     active_junction_ids = Set(
@@ -1116,7 +1116,7 @@ function _check_status(data::Dict{String,<:Any})
                 if haskey(comp, junc_key)
                     if get(comp, "status", 1) != 0 &&
                        !(comp[junc_key] in active_junction_ids)
-                        Memento.warn(_LOGGER, "active $comp_type $i is connected to inactive junction $(comp[junc_key])")
+                        @warn ("active $comp_type $i is connected to inactive junction $(comp[junc_key])")
                     end
                 end
             end
@@ -1134,14 +1134,14 @@ end
 "checks that all edges connect two distinct junctions"
 function _check_edge_loops(data::Dict{String,<:Any})
     if _IM.ismultinetwork(data)
-        Memento.error(_LOGGER, "check_edge_loops does not yet support multinetwork data")
+        error("check_edge_loops does not yet support multinetwork data")
     end
 
     for edge_type in _gm_edge_types
         if haskey(data, edge_type)
             for edge in values(data[edge_type])
                 if edge["fr_junction"] == edge["to_junction"]
-                    Memento.error(_LOGGER, "both sides of $edge_type $(edge["index"]) connect to junction $(edge["fr_junction"])")
+                    error("both sides of $edge_type $(edge["index"]) connect to junction $(edge["fr_junction"])")
                 end
             end
         end
@@ -1165,7 +1165,7 @@ function _propagate_topology_status!(data::Dict{String,<:Any})
                 for junc_key in _gm_junction_keys
                     if haskey(comp, junc_key) && comp[junc_key] in disabled_junctions
                         comp["status"] = 0
-                        Memento.info(_LOGGER, "Change status of $comp_type $(comp["index"]) because connecting junction $(comp[junc_key]) is disabled")
+                        @info ("Change status of $comp_type $(comp["index"]) because connecting junction $(comp[junc_key]) is disabled")
                         break
                     end
                 end
@@ -1894,7 +1894,7 @@ function calc_connected_components(data::Dict{String,<:Any}; edges = _gm_edge_ty
     gm_data = get_gm_data(data)
 
     if _IM.ismultinetwork(gm_data)
-        Memento.error(_LOGGER, "calc_connected_components does not yet support multinetwork data")
+        error("calc_connected_components does not yet support multinetwork data")
     end
 
     active_junction = Dict(x for x in gm_data["junction"] if x.second["status"] != 0)
@@ -1934,17 +1934,17 @@ function _select_largest_component!(data::Dict{String,<:Any})
     ccs = calc_connected_components(data)
 
     if length(ccs) > 1
-        Memento.info(_LOGGER, "found $(length(ccs)) components")
+        @info ("found $(length(ccs)) components")
 
         ccs_order = sort(collect(ccs); by=length)
         largest_cc = ccs_order[end]
 
-        Memento.info(_LOGGER, "largest component has $(length(largest_cc)) junctions")
+        @info ("largest component has $(length(largest_cc)) junctions")
 
         for (i,junction) in data["junction"]
             if junction["status"] != 0 && !(junction["id"] in largest_cc)
                 junction["status"] = 0
-                Memento.info(_LOGGER, "deactivating junction $(i) due to small connected component")
+                @info ("deactivating junction $(i) due to small connected component")
             end
         end
 

--- a/src/core/logging.jl
+++ b/src/core/logging.jl
@@ -1,0 +1,85 @@
+"""
+    _pm_metafmt(level::Logging.LogLevel, _module, group, id, file, line)
+
+MetaFormatter for ConsoleLogger for GasModels to adjust log message format
+"""
+function _gm_metafmt(level::Logging.LogLevel, _module, group, id, file, line)
+    @nospecialize
+    color = Logging.default_logcolor(level)
+    prefix = "$(_module) | " * (level == Logging.Warn ? "Warning" : string(level)) * " ] :"
+    suffix = ""
+    Logging.Info <= level < Logging.Warn && return color, prefix, suffix
+    _module !== nothing && (suffix *= "$(_module)")
+    if file !== nothing
+        _module !== nothing && (suffix *= " ")
+        suffix *= Base.contractuser(file)
+        if line !== nothing
+            suffix *= ":$(isa(line, UnitRange) ? "$(first(line))-$(last(line))" : line)"
+        end
+    end
+    !isempty(suffix) && (suffix = "@ " * suffix)
+
+    return color, prefix, suffix
+end
+
+
+"""
+    silence!()
+
+Sets loglevel for GasModels to `:Error`, silencing Info and Warn
+"""
+function silence!()
+    set_logging_level!(:Error)
+end
+
+
+"""
+    reset_logging_level!()
+
+Resets the log level to Info
+"""
+function reset_logging_level!()
+    Logging.global_logger(_LOGGER)
+
+    return
+end
+
+
+"""
+    restore_global_logger!()
+
+Restores the global logger to its default state (before GasModels was loaded)
+"""
+function restore_global_logger!()
+    Logging.global_logger(_DEFAULT_LOGGER)
+
+    return
+end
+
+
+"""
+    set_logging_level!(level::Symbol)
+
+Sets the logging level for GasModels: `:Info`, `:Warn`, `:Error`
+"""
+function set_logging_level!(level::Symbol)
+    Logging.global_logger(_make_filtered_logger(getfield(Logging, level)))
+
+    return
+end
+
+
+"""
+    _make_filtered_logger(level::Logging.LogLevel)
+
+Helper function to create the filtered logger for GasModels
+"""
+function _make_filtered_logger(level)
+    LoggingExtras.EarlyFilteredLogger(_LOGGER) do log
+        if log._module == GasModels && log.level < level
+            return false
+        else
+            return true
+        end
+    end
+end

--- a/src/core/ref.jl
+++ b/src/core/ref.jl
@@ -134,11 +134,11 @@ function ref_add_transient!(ref::Dict{Symbol,<:Any}, data::Dict{String,<:Any})
         end
 
         if length(slack_junctions) == 0
-            Memento.warn(_LOGGER, "No slack junctions found in the data - add a slack junction")
+            @warn ("No slack junctions found in the data - add a slack junction")
         end
 
         if length(slack_junctions) > 1
-            Memento.warn(_LOGGER, "multiple slack junctions, $(keys(slack_junctions))")
+            @warn ("multiple slack junctions, $(keys(slack_junctions))")
         end
 
         nw_ref[:slack_junctions] = slack_junctions

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -11,7 +11,7 @@ function parse_file(io::IO; filetype::AbstractString = "m", skip_correct::Bool =
     elseif filetype == "zip"
         gm_data = GasModels.parse_gaslib(io)
     else
-        Memento.error(_LOGGER, "only .m and .json files are supported")
+        error("only .m and .json files are supported")
     end
 
     if !skip_correct
@@ -46,10 +46,10 @@ function check_pipeline_geometry!(data::Dict{String,Any})
         diameter = pipe["diameter"]
 
         if length <= 0.0
-            Memento.error(_LOGGER, "Pipeline $pipe_id has non-positive length: $length")
+            error("Pipeline $pipe_id has non-positive length: $length")
         end
         if diameter <= 0.0
-            Memento.error(_LOGGER, "Pipeline $pipe_id has non-positive diameter: $diameter")
+            error("Pipeline $pipe_id has non-positive diameter: $diameter")
         end
 
         # Convert junction indices to strings before lookup
@@ -63,11 +63,11 @@ function check_pipeline_geometry!(data::Dict{String,Any})
             if haskey(f_junc, "elevation") && haskey(t_junc, "elevation")
                 dz = abs(f_junc["elevation"] - t_junc["elevation"])
                 if dz > length
-                    Memento.error(_LOGGER, "Pipeline $pipe_id has elevation change ($dz) greater than length ($length)")
+                    error("Pipeline $pipe_id has elevation change ($dz) greater than length ($length)")
                 end
             end
         else
-            Memento.warn(_LOGGER,"Pipeline $pipe_id refers to missing junction(s): $fr_id or $to_id")
+            @warn ("Pipeline $pipe_id refers to missing junction(s): $fr_id or $to_id")
         end
     end
 end
@@ -88,8 +88,7 @@ function check_soundspeed!(mn_data::Dict{String,Any}; tol=0.5)
 
     #check for mismatch
     if abs(a_given - a_expected) > tol
-        Memento.warn(
-            _LOGGER,
+        @warn(
             "Sound speed mismatch: provided=$(a_given), calculated=$(a_expected), Δ=$(a_given - a_expected). The calculated speed will be used."
         )
     end

--- a/src/io/gaslib.jl
+++ b/src/io/gaslib.jl
@@ -27,8 +27,7 @@ function parse_gaslib(zip_path::Union{IO,String})
         nomination_xml = _parse_xml_file(zip_reader, fid)
 
         # Print a warning message stating that the above file is being used.
-        Memento.warn(
-            _LOGGER,
+        @warn(
             "Multiple nomination file paths found " *
             "in GasLib data. Selecting last nomination file " *
             "(i.e., \"$(file_paths[fid])\") " *

--- a/src/io/matgas.jl
+++ b/src/io/matgas.jl
@@ -329,7 +329,7 @@ function parse_m_string(data_string::String)
     if func_name !== nothing
         case["name"] = func_name
     else
-        Memento.warn(_LOGGER, "no case name found in .m file.  The file seems to be missing \"function mgc = ...\"")
+        @warn ("no case name found in .m file.  The file seems to be missing \"function mgc = ...\"")
         case["name"] = "no_name_found"
     end
 
@@ -337,7 +337,7 @@ function parse_m_string(data_string::String)
     if haskey(matlab_data, "mgc.version")
         case["source_version"] = VersionNumber(matlab_data["mgc.version"])
     else
-        Memento.warn(_LOGGER, "no case version found in .m file.  The file seems to be missing \"mgc.version = ...\"")
+        @warn ("no case version found in .m file.  The file seems to be missing \"mgc.version = ...\"")
         case["source_version"] = "0.0.0+"
     end
 
@@ -365,7 +365,7 @@ function parse_m_string(data_string::String)
         if haskey(matlab_data, data_name)
             case[data_name[5:end]] = matlab_data[data_name]
         else
-            Memento.error(_LOGGER, string("no $data_name found in .m file"))
+            error(string("no $data_name found in .m file"))
         end
     end
 
@@ -378,10 +378,10 @@ function parse_m_string(data_string::String)
             case["english_units"] = true
             case["si_units"] = false
         else
-            Memento.error(_LOGGER, string("the possible values for units field in .m file are \"si\" or \"usc\""))
+            error(string("the possible values for units field in .m file are \"si\" or \"usc\""))
         end
     else
-        Memento.error(_LOGGER, string("no units field found in .m file.
+        error(string("no units field found in .m file.
         The file seems to be missing \"mgc.units = ...;\" \n
         Possible values are 1 (SI) or 2 (English units)"))
     end
@@ -390,24 +390,23 @@ function parse_m_string(data_string::String)
     if haskey(matlab_data, "mgc.base_pressure")
         case["base_pressure"] = matlab_data["mgc.base_pressure"]
     else
-        Memento.warn(
-            _LOGGER,
-            string("no base_pressure found in .m file.
-This value will be auto-assigned based on the pressure limits provided in the data"),
+        @warn(
+            "no base_pressure found in .m file.
+This value will be auto-assigned based on the pressure limits provided in the data"
         )
     end
 
     if haskey(matlab_data, "mgc.base_length")
         case["base_length"] = matlab_data["mgc.base_length"]
     else
-        Memento.warn(_LOGGER, string("no base_length found in .m file.
-            This value will be auto-assigned based on the pipe data"))
+        @warn string("no base_length found in .m file.
+            This value will be auto-assigned based on the pipe data")
     end
 
     if haskey(matlab_data, "mgc.is_per_unit")
         case["per_unit"] = matlab_data["mgc.is_per_unit"]
     else
-        Memento.warn(_LOGGER, string("no is_per_unit found in .m file.
+        @warn (string("no is_per_unit found in .m file.
             Auto assigning a value of 0 (false) for the per_unit field"))
         case["per_unit"] = false
     end
@@ -438,8 +437,7 @@ This value will be auto-assigned based on the pressure limits provided in the da
         case["economic_weighting"] = matlab_data["mgc.economic_weighting"]
     else
         case["economic_weighting"] = 1.0
-        Memento.warn(
-            _LOGGER,
+        @warn (
             "economic_weighting value set to 1.0; the transient ogf
 objective is economic_weighting * (load shed) +
 (1-economic_weighting) * (compressor power)",
@@ -470,7 +468,7 @@ objective is economic_weighting * (load shed) +
         end
         case["junction"] = junctions
     else
-        Memento.error(_LOGGER, string("no junction table found in .m file.
+        error(string("no junction table found in .m file.
             The file seems to be missing \"mgc.junction = [...];\""))
     end
 
@@ -489,7 +487,7 @@ objective is economic_weighting * (load shed) +
         end
         case["pipe"] = pipes
     else
-        Memento.error(_LOGGER, string("no pipe table found in .m file.
+        error(string("no pipe table found in .m file.
             The file seems to be missing \"mgc.pipe = [...];\""))
     end
 
@@ -686,10 +684,10 @@ objective is economic_weighting * (load shed) +
                     push!(tbl, row_data)
                 end
                 case[case_name] = tbl
-                Memento.info(_LOGGER, "extending matlab format with data: $(case_name) $(length(tbl))x$(length(tbl[1])-1)")
+                @info ("extending matlab format with data: $(case_name) $(length(tbl))x$(length(tbl[1])-1)")
             else
                 case[case_name] = value
-                Memento.info(_LOGGER, "extending matlab format with constant data: $(case_name)")
+                @info ("extending matlab format with constant data: $(case_name)")
             end
         end
     end
@@ -720,7 +718,7 @@ function _matgas_to_gasmodels(mg_data::Dict{String,Any})
 
     num_supplies = receipts + transfers + storages
     if num_supplies == 0
-        Memento.warn(_LOGGER, "no supply points are present in the data file")
+        @warn ("no supply points are present in the data file")
     end
 
     for field in check_fields
@@ -751,17 +749,17 @@ function _merge_generic_data!(data::Dict{String,Any})
                     push!(key_to_delete, k)
 
                     if length(mg_matrix) != length(v)
-                        Memento.error(_LOGGER, "failed to extend the matlab matrix \"$(mg_name)\" with the matrix \"$(k)\" because they do not have the same number of rows, $(length(mg_matrix)) and $(length(v)) respectively.")
+                        error("failed to extend the matlab matrix \"$(mg_name)\" with the matrix \"$(k)\" because they do not have the same number of rows, $(length(mg_matrix)) and $(length(v)) respectively.")
                     end
 
-                    Memento.info(_LOGGER, "extending matlab format by appending matrix \"$(k)\" in to \"$(mg_name)\"")
+                    @info ("extending matlab format by appending matrix \"$(k)\" in to \"$(mg_name)\"")
 
                     for (i, row) in enumerate(mg_matrix)
                         merge_row = v[i]
                         delete!(merge_row, "index")
                         for key in keys(merge_row)
                             if haskey(row, key)
-                                Memento.error(_LOGGER, "failed to extend the matlab matrix \"$(mg_name)\" with the matrix \"$(k)\" because they both share \"$(key)\" as a column name.")
+                                error("failed to extend the matlab matrix \"$(mg_name)\" with the matrix \"$(k)\" because they both share \"$(key)\" as a column name.")
                             end
                             row[key] = merge_row[key]
                         end
@@ -998,8 +996,7 @@ function _gasmodels_to_matgas_string(
                         else
                             # special handling for the optional edi_id column
                             field == "edi_id" ? push!(entries, "0") :
-                                Memento.error(_LOGGER,
-                                    string("$(data_type) $(i) is missing field $(field)"))
+                                    error(string("$(data_type) $(i) is missing field $(field)"))
                         end
                     end
                     push!(lines, "$(join(entries, "\t"))")

--- a/src/io/multinetwork.jl
+++ b/src/io/multinetwork.jl
@@ -39,8 +39,7 @@ function _create_tsb(
         if !haskey(root, comp_type)
             root[comp_type] = Dict{String,Any}()
         elseif !(root[comp_type] isa Dict)
-            Memento.error(_LOGGER,
-                "Inconsistent column naming – \"$comp_type\" is both a parameter and a container")
+                error("Inconsistent column naming – \"$comp_type\" is both a parameter and a container")
         end
         comp_type_dict = root[comp_type]
 
@@ -48,8 +47,7 @@ function _create_tsb(
         if !haskey(comp_type_dict, comp_id)
             comp_type_dict[comp_id] = Dict{String,Any}()
         elseif !(comp_type_dict[comp_id] isa Dict)
-            Memento.error(_LOGGER,
-                "Inconsistent column naming – \"$comp_id\" is both a parameter and a container")
+                error("Inconsistent column naming – \"$comp_id\" is both a parameter and a container")
         end
         id_dict = comp_type_dict[comp_id]
 
@@ -57,8 +55,7 @@ function _create_tsb(
         if !haskey(id_dict, param)
             id_dict[param] = Vector{Any}(undef, n_steps)
         elseif !(id_dict[param] isa Vector)
-            Memento.error(_LOGGER,
-                "Inconsistent column naming – \"$param\" is both a container and a parameter")
+                error("Inconsistent column naming – \"$param\" is both a container and a parameter")
         end
         return id_dict[param]   # the leaf vector
     end

--- a/src/io/transient.jl
+++ b/src/io/transient.jl
@@ -357,20 +357,18 @@ function _create_time_series_block(
     end_time = total_time + additional_time
 
     if (time_step > 3600.0 && time_step % 3600.0 != 0.0)
-        Memento.error(
-            _LOGGER,
+        error(
             "the 3600 seconds has to be exactly divisible by the time step,
 provide a time step that exactly divides 3600.0",
         )
     end
 
     if time_step < 3600.0 && !isinteger(3600.0 / time_step)
-        Memento.error(_LOGGER, "time step should divide 3600.0 exactly when < 3600.0")
+        error("time step should divide 3600.0 exactly when < 3600.0")
     end
 
     if total_time > 86400.0
-        Memento.warn(
-            _LOGGER,
+        @warn (
             "the solver takes a substantial performance hit when trying to solve
 transient optimization problems for more than a day's worth of data; if it takes too long to
 converge, please restrict the final time horizon to a day or less",
@@ -378,8 +376,7 @@ converge, please restrict the final time horizon to a day or less",
     end
 
     if (additional_time == 0.0)
-        Memento.warn(
-            _LOGGER,
+        @warn(
             "the transient optimization problem will only work for time-periodic
 time-series data. Please ensure the time-series data is time-periodic with a period of $total_time;
 if the data is not time-periodic GasModels will perform a time-periodic spline interpolation if

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,15 +1,9 @@
 using GasModels
 
 import InfrastructureModels
-import Memento
 import Logging
 
-# Suppress warnings during testing.
-const TESTLOG = Memento.getlogger(GasModels)
-Memento.setlevel!(TESTLOG, "error")
-Memento.setlevel!(Memento.getlogger(InfrastructureModels), "error")
-Logging.disable_logging(Logging.Info)
-Logging.disable_logging(Logging.Warn)
+GasModels.silence!()
 
 import JuMP
 


### PR DESCRIPTION
This is a mirror of the current InfrastructureModels and PowerModels PRs opened by @Ksepetanc. All the memento calls have been swapped for base julia error, warn, and info functions. 

I also bumped the julia version requirement to 1.10, in line with issue #287. @ccoffrin agreed in [InfrastructureModels#96](https://github.com/lanl-ansi/InfrastructureModels.jl/issues/96) that this would be a good change across the IMs family of packages. 