### PR TITLE
prep for v0.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## staged 
 - nothing
 
+## v0.13.0
+- Remove Memento and switch to Logging.jl
+- Drop support for Julia 1.6 and move base version requirement to 1.10LTS.
+- Update Documenter.jl to current version
+
 ## v0.12.0
 - change units flags from 1 or 0 (`is_english_units = 0`) to booleans (`per_unit = true`)
 - this is a breaking change for any code that asserts/checks/modifies the units flag

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "GasModels"
 uuid = "5e113713-6c35-5477-b766-e1109486666f"
 authors = ["Russell Bent <rbent@lanl.gov>", "Kaarthik Sundar <kaarthik@lanl.gov>", "David Fobes <dfobes@lanl.gov>"]
 repo = "https://github.com/lanl-ansi/GasModels.jl.git"
-version = "0.12.0"
+version = "0.13.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
## v0.13.0
- Remove Memento and switch to Logging.jl
- Drop support for Julia 1.6 and move base version requirement to 1.10LTS.
- Update Documenter.jl to current version
