### PR TITLE
Updating nominal OGF behavior for transfers

### DIFF
--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -208,7 +208,14 @@ end
 
 
 "Template: Constraints for mass flow balance equation where demand and production is are a mix of constants and variables"
-function constraint_mass_flow_balance(gm::AbstractGasModel, i; n::Int = nw_id_default)
+function constraint_mass_flow_balance(gm::AbstractGasModel, i; n::Int = nw_id_default, is_nominal::Bool = false)
+    receipt_min(receipt) = receipt["injection_min"]
+    receipt_max(receipt) = is_nominal ? receipt["injection_nominal"] : receipt["injection_max"]
+    delivery_min(delivery) = delivery["withdrawal_min"]
+    delivery_max(delivery) = is_nominal ? delivery["withdrawal_nominal"] : delivery["withdrawal_max"]
+    transfer_min(transfer) = is_nominal ? min(0.0, transfer["withdrawal_nominal"]) : transfer["withdrawal_min"]
+    transfer_max(transfer) = is_nominal ? max(0.0, transfer["withdrawal_nominal"]) : transfer["withdrawal_max"]
+
     junction = ref(gm, n, :junction, i)
     f_pipes = ref(gm, n, :pipes_fr, i)
     t_pipes = ref(gm, n, :pipes_to, i)
@@ -238,12 +245,12 @@ function constraint_mass_flow_balance(gm::AbstractGasModel, i; n::Int = nw_id_de
     fg = length(nondispatch_receipts) > 0 ? sum(receipt[j]["injection_nominal"] for j in nondispatch_receipts) : 0
     fl = length(nondispatch_deliveries) > 0 ? sum(delivery[j]["withdrawal_nominal"] for j in nondispatch_deliveries) : 0
     fl += length(nondispatch_transfers) > 0 ? sum(transfer[j]["withdrawal_nominal"] for j in nondispatch_transfers) : 0
-    fgmax = length(dispatch_receipts) > 0 ? sum(receipt[j]["injection_max"] for j in dispatch_receipts) : 0
-    flmax = length(dispatch_deliveries) > 0 ? sum(delivery[j]["withdrawal_max"] for j in dispatch_deliveries) : 0
-    flmax += length(dispatch_transfers) > 0 ? sum(transfer[j]["withdrawal_max"] for j in dispatch_transfers) : 0
-    fgmin = length(dispatch_receipts) > 0 ? sum(receipt[j]["injection_min"] for j in dispatch_receipts) : 0
-    flmin = length(dispatch_deliveries) > 0 ? sum(delivery[j]["withdrawal_min"] for j in dispatch_deliveries) : 0
-    flmin += length(dispatch_transfers) > 0 ? sum(transfer[j]["withdrawal_min"] for j in dispatch_transfers) : 0
+    fgmax = length(dispatch_receipts) > 0 ? sum(receipt_max(receipt[j]) for j in dispatch_receipts) : 0
+    flmax = length(dispatch_deliveries) > 0 ? sum(delivery_max(delivery[j]) for j in dispatch_deliveries) : 0
+    flmax += length(dispatch_transfers) > 0 ? sum(transfer_max(transfer[j]) for j in dispatch_transfers) : 0
+    fgmin = length(dispatch_receipts) > 0 ? sum(receipt_min(receipt[j]) for j in dispatch_receipts) : 0
+    flmin = length(dispatch_deliveries) > 0 ? sum(delivery_min(delivery[j]) for j in dispatch_deliveries) : 0
+    flmin += length(dispatch_transfers) > 0 ? sum(transfer_min(transfer[j]) for j in dispatch_transfers) : 0
 
     constraint_mass_flow_balance(gm, n, i, f_pipes, t_pipes, f_compressors, t_compressors, f_resistors, t_resistors, f_loss_resistors, t_loss_resistors, f_short_pipes, t_short_pipes, f_valves, t_valves, f_regulators, t_regulators, fl, fg, dispatch_deliveries, dispatch_receipts, dispatch_transfers, storages, flmin, flmax, fgmin, fgmax)
 end

--- a/src/core/objective.jl
+++ b/src/core/objective.jl
@@ -71,7 +71,11 @@ end
 
 "function for minimizing economic costs: ``\\min \\sum_{j \\in {\\cal D}} \\kappa_j \\boldsymbol{d}_j - \\sum_{j \\in {\\cal T}} \\kappa_j \\boldsymbol{\\tau}_j - \\sum_{j \\in {\\cal R}} \\kappa_j \\boldsymbol{r}_j -
     \\sum_{ijk \\in {\\cal C}} \\boldsymbol{f}_{ijk} (\\boldsymbol{\\alpha}_{ijk}^m - 1)``"
-function objective_min_economic_costs(gm::AbstractGasModel, nws = [nw_id_default])
+function objective_min_economic_costs(gm::AbstractGasModel, nws = [nw_id_default]; is_nominal::Bool=false)
+    transfer_price_key = is_nominal ? "withdrawal_nominal" : "withdrawal_min"
+    transfer_price(transfer) = transfer[transfer_price_key] >= 0.0 ?
+        get(transfer, "bid_price", 1.0) : (-1) * get(transfer, "offer_price", 1.0)
+
     r = Dict(n => var(gm, n, :rsqr) for n in nws)
     f = Dict(n => var(gm, n, :f_compressor) for n in nws)
     fl = Dict(n => var(gm, n, :fl) for n in nws)
@@ -111,7 +115,7 @@ function objective_min_economic_costs(gm::AbstractGasModel, nws = [nw_id_default
     )
     transfer_prices = Dict(
         n => Dict(
-            i => ref(gm, n, :transfer, i)["withdrawal_min"] >= 0.0 ?  get(ref(gm, n, :transfer, i), "bid_price", 1.0) : (-1) * get(ref(gm, n, :transfer, i), "offer_price", 1.0) for i in transfer_set[n]
+            i => transfer_price(ref(gm, n, :transfer, i)) for i in transfer_set[n]
         ) for n in nws
     )
 

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -324,19 +324,23 @@ end
 
 "variables associated with transfer"
 function variable_transfer_mass_flow(gm::AbstractGasModel, nw::Int=nw_id_default; bounded::Bool=true, report::Bool=true, is_nominal::Bool=false)
-    withdrawal_type = is_nominal ? "withdrawal_nominal" : "withdrawal_max"
+    flow_start(transfer) = is_nominal ? transfer["withdrawal_nominal"] :
+        (transfer["withdrawal_min"] < 0.0 ? transfer["withdrawal_min"] : transfer["withdrawal_max"])
+
+    flow_bounds(transfer) = is_nominal ? minmax(0.0, transfer["withdrawal_nominal"]) :
+        (transfer["withdrawal_min"], transfer["withdrawal_max"])
+
     ft = var(gm, nw)[:ft] = JuMP.@variable(gm.model,
         [i in ids(gm,nw,:dispatchable_transfer)],
         base_name="$(nw)_ft",
-        start= ref(gm, nw, :transfer, i)["withdrawal_min"] < 0.0 ?
-            ref(gm, nw, :transfer, i)["withdrawal_min"] :
-            ref(gm, nw, :transfer, i)[withdrawal_type]
+        start=flow_start(ref(gm, nw, :transfer, i))
     )
 
     if bounded
         for (i, transfer) in ref(gm, nw, :dispatchable_transfer)
-            JuMP.set_lower_bound(ft[i], ref(gm, nw, :transfer, i)["withdrawal_min"])
-            JuMP.set_upper_bound(ft[i], ref(gm, nw, :transfer, i)[withdrawal_type])
+            lb, ub = flow_bounds(transfer)
+            JuMP.set_lower_bound(ft[i], lb)
+            JuMP.set_upper_bound(ft[i], ub)
         end
     end
 

--- a/src/prob/ogf.jl
+++ b/src/prob/ogf.jl
@@ -147,10 +147,10 @@ function build_ogf_nominal(gm::AbstractGasModel)
     variable_storage(gm)
     variable_form_specific(gm)
 
-    objective_min_economic_costs(gm)
+    objective_min_economic_costs(gm, is_nominal=true)
 
     for (i, junction) in ref(gm, :junction)
-        constraint_mass_flow_balance(gm, i)
+        constraint_mass_flow_balance(gm, i, is_nominal=true)
 
         if (junction["junction_type"] == 1)
             constraint_pressure(gm, i)

--- a/test/ogf_nominal.jl
+++ b/test/ogf_nominal.jl
@@ -1,4 +1,26 @@
 @testset "test ogf nominal" begin
+    @testset "nominal dispatch variable bounds" begin
+        data = GasModels.parse_file("../test/data/matgas/case-6-nels.m")
+        transfer = data["transfer"]["1"]
+        transfer["is_dispatchable"] = 1
+        transfer["withdrawal_min"] = -12.0
+        transfer["withdrawal_max"] = 30.0
+        transfer["withdrawal_nominal"] = -5.0
+        gm = GasModels.instantiate_model(data, WPGasModel, GasModels.build_ogf_nominal)
+
+        receipt = ref(gm, :receipt, 1)
+        delivery = ref(gm, :delivery, 1)
+        fg = var(gm, :fg)[1]
+        fl = var(gm, :fl)[1]
+        ft = var(gm, :ft)[1]
+
+        @test (JuMP.lower_bound(fg), JuMP.upper_bound(fg), JuMP.start_value(fg)) ==
+              (receipt["injection_min"], receipt["injection_nominal"], receipt["injection_nominal"])
+        @test (JuMP.lower_bound(fl), JuMP.upper_bound(fl), JuMP.start_value(fl)) ==
+              (delivery["withdrawal_min"], delivery["withdrawal_nominal"], delivery["withdrawal_nominal"])
+        @test (JuMP.lower_bound(ft), JuMP.upper_bound(ft), JuMP.start_value(ft)) == (-5.0, 0.0, -5.0)
+    end
+
     @testset "test wp ogf nominal" begin
         @testset "case 6 ogf nominal" begin
             @_info "Testing OGF Nominal"
@@ -8,6 +30,18 @@
             @test isapprox(result["objective"], -253.683; atol = 1e-2)
             GasModels.make_si_units!(result["solution"])
             @test isapprox(result["solution"]["receipt"]["1"]["fg"], 123.6821; atol = 1e-2)
+        end
+
+        @testset "case 6 ogf nominal modified transfer" begin
+            @_info "Testing OGF Nominal Modified transfer"
+            data = GasModels.parse_file("../test/data/matgas/case-6-no-power-limits-nominal.m")
+            transfer = data["transfer"]["1"]
+            transfer["withdrawal_nominal"] = - transfer["withdrawal_max"] / 2.0
+
+            result = solve_ogf_nominal(data, WPGasModel, nlp_solver)
+            GasModels.make_si_units!(result["solution"])
+            @test result["termination_status"] in [LOCALLY_SOLVED, ALMOST_LOCALLY_SOLVED, OPTIMAL, :Suboptimal]
+            @test isapprox(result["solution"]["transfer"]["1"]["ft"], -15.0; atol = 1e-2)
         end
 
         @testset "case 6 ogf nominal" begin


### PR DESCRIPTION
This PR updates nominal OGF transfer handling to consistently use the sign of nominal transfer values when determining bounds, pricing behavior, and mass flow balancing.

Updated transfer upper/lower bound logic to derive bounds from the sign of nominal transfer values
Updated objective pricing behavior to use the sign of nominal transfer values
Updated constraint_mass_flow_balance to use nominal transfer values instead of min/max bounds
Added test coverage for the updated transfer behavior