### PR TITLE
allow `is_dispatchable = 0` components in solution

### DIFF
--- a/src/core/solution.jl
+++ b/src/core/solution.jl
@@ -204,7 +204,7 @@ function _backfill_is_dispatchable_zero_components!(
     ids0 = _is_dispatchable_zero_missing_ids(gm, n, nw_data, nw_sol, comp_name)
 
     if isempty(ids0)
-        @_info("[dispatchable-zero] no components to backfill for ", comp_name, " on network ", n)
+        @_info(string("[dispatchable-zero] no components to backfill for ", comp_name, " on network ", n))
         return
     end
 
@@ -227,17 +227,17 @@ function _backfill_is_dispatchable_zero_components!(
             if haskey(dat, data_field)
                 sol[sol_var] = dat[data_field]
             else
-                @_info(
+                @_info(string(
                     "[dispatchable-zero]   MISSING required data field ",
                     data_field,
                     " for ",
                     comp_key,
                     " ",
                     k,
-                )
+                ))
             end
         end
 
-        @_info("[dispatchable-zero]   final sol entry: ", sol)
+        @_info(string("[dispatchable-zero]   final sol entry: ", sol))
     end
 end

--- a/src/core/solution.jl
+++ b/src/core/solution.jl
@@ -121,3 +121,110 @@ function sol_regulator_p_to_r!(gm::AbstractGasModel, solution::Dict)
         end
     end
 end
+
+const _IS_DISPATCHABLE_ZERO_DEFAULTS = Dict(
+    :receipt => Dict("fg" => "injection_nominal"),
+    :delivery => Dict("fd" => "withdrawal_nominal"),
+    :transfer => Dict("ft" => "withdrawal_nominal"),
+)
+
+function sol_is_dispatchable_zero_components!(gm::AbstractGasModel, solution::Dict)
+    if haskey(solution["it"][gm_it_name], "nw")
+        nws_sol = solution["it"][gm_it_name]["nw"]
+    else
+        nws_sol = Dict("0" => solution["it"][gm_it_name])
+    end
+
+    nws_data =
+        if get(gm.data, "multinetwork", false)
+            gm.data["nw"]
+        else
+            Dict("0" => gm.data)
+        end
+
+    for (n_str, nw_sol) in nws_sol
+        n = parse(Int, n_str)
+        nw_data = nws_data[n_str]
+
+        for (comp_name, defaults) in _IS_DISPATCHABLE_ZERO_DEFAULTS
+            _backfill_is_dispatchable_zero_components!(
+                gm,
+                n,
+                nw_data,
+                nw_sol,
+                comp_name,
+                defaults,
+            )
+        end
+    end
+end
+
+function _is_dispatchable_zero_missing_ids(
+    gm::AbstractGasModel,
+    n::Int,
+    nw_data::Dict,
+    nw_sol::Dict,
+    comp_name::Symbol,
+)
+    comp_key = string(comp_name)
+
+    if !haskey(nw_data, comp_key)
+        return Int[]
+    end
+
+    data_comps = nw_data[comp_key]
+    sol_comps = get(nw_sol, comp_key, Dict{String,Any}())
+
+    ref_ids = Set(ids(gm, n, comp_name))
+    out = Int[]
+
+    for (k, data_comp) in data_comps
+        i = parse(Int, k)
+
+        if get(data_comp, "is_dispatchable", 1) == 0 &&
+           !(i in ref_ids) &&
+           !haskey(sol_comps, k)
+            push!(out, i)
+        end
+    end
+
+    return out
+end
+
+function _backfill_is_dispatchable_zero_components!(
+    gm::AbstractGasModel,
+    n::Int,
+    nw_data::Dict,
+    nw_sol::Dict,
+    comp_name::Symbol,
+    defaults::Dict{String,String},
+)
+    ids0 = _is_dispatchable_zero_missing_ids(gm, n, nw_data, nw_sol, comp_name)
+    isempty(ids0) && return
+
+    comp_key = string(comp_name)
+    data_comps = nw_data[comp_key]
+    sol_comps = get!(nw_sol, comp_key, Dict{String,Any}())
+
+    for i in ids0
+        k = string(i)
+        dat = data_comps[k]
+        sol = get!(sol_comps, k, Dict{String,Any}())
+
+        sol["is_dispatchable"] = 0
+
+        if haskey(dat, "status")
+            sol["status"] = dat["status"]
+        end
+
+        for (sol_var, data_field) in defaults
+            if haskey(dat, data_field)
+                sol[sol_var] = dat[data_field]
+            else
+                @_warn(
+                    "Cannot backfill non-dispatchable $(comp_key) $(k): missing field `$(data_field)`"
+                )
+            end
+        end
+    end
+end

--- a/src/core/solution.jl
+++ b/src/core/solution.jl
@@ -122,29 +122,25 @@ function sol_regulator_p_to_r!(gm::AbstractGasModel, solution::Dict)
     end
 end
 
-const IS_DISPATCHABLE_ZERO_DEFAULTS = Dict(
+const _IS_DISPATCHABLE_ZERO_DEFAULTS = Dict(
     :receipt => Dict("fg" => "injection_nominal"),
     :delivery => Dict("fd" => "withdrawal_nominal"),
     :transfer => Dict("ft" => "withdrawal_nominal"),
 )
 
 function sol_is_dispatchable_zero_components!(gm::AbstractGasModel, solution::Dict)
-    println("[dispatchable-zero] entered processor")
+    @_info("[dispatchable-zero] entered processor")
 
     if haskey(solution["it"][gm_it_name], "nw")
         nws_sol = solution["it"][gm_it_name]["nw"]
-        println("[dispatchable-zero] solution is multinetwork with networks: ", collect(keys(nws_sol)))
     else
         nws_sol = Dict("0" => solution["it"][gm_it_name])
-        println("[dispatchable-zero] solution is single network")
     end
 
     nws_data =
         if get(gm.data, "multinetwork", false)
-            println("[dispatchable-zero] gm.data is multinetwork with networks: ", collect(keys(gm.data["nw"])))
             gm.data["nw"]
         else
-            println("[dispatchable-zero] gm.data is single network")
             Dict("0" => gm.data)
         end
 
@@ -152,12 +148,7 @@ function sol_is_dispatchable_zero_components!(gm::AbstractGasModel, solution::Di
         n = parse(Int, n_str)
         nw_data = nws_data[n_str]
 
-        println("[dispatchable-zero] processing network ", n_str)
-        println("[dispatchable-zero] nw_sol component keys: ", collect(keys(nw_sol)))
-        println("[dispatchable-zero] nw_data component keys: ", collect(keys(nw_data)))
-
-        for (comp_name, defaults) in IS_DISPATCHABLE_ZERO_DEFAULTS
-            println("[dispatchable-zero] checking component type: ", comp_name)
+        for (comp_name, defaults) in _IS_DISPATCHABLE_ZERO_DEFAULTS
             _backfill_is_dispatchable_zero_components!(
                 gm,
                 n,
@@ -169,7 +160,7 @@ function sol_is_dispatchable_zero_components!(gm::AbstractGasModel, solution::Di
         end
     end
 
-    println("[dispatchable-zero] finished processor")
+    @_info("[dispatchable-zero] finished processor")
 end
 
 function _is_dispatchable_zero_missing_ids(
@@ -201,6 +192,7 @@ function _is_dispatchable_zero_missing_ids(
 
     return out
 end
+
 function _backfill_is_dispatchable_zero_components!(
     gm::AbstractGasModel,
     n::Int,
@@ -212,7 +204,7 @@ function _backfill_is_dispatchable_zero_components!(
     ids0 = _is_dispatchable_zero_missing_ids(gm, n, nw_data, nw_sol, comp_name)
 
     if isempty(ids0)
-        println("[dispatchable-zero] no components to backfill for ", comp_name, " on network ", n)
+        @_info("[dispatchable-zero] no components to backfill for ", comp_name, " on network ", n)
         return
     end
 
@@ -225,30 +217,17 @@ function _backfill_is_dispatchable_zero_components!(
         dat = data_comps[k]
         sol = get!(sol_comps, k, Dict{String,Any}())
 
-        println("[dispatchable-zero] backfilling ", comp_key, " ", k)
-        println("[dispatchable-zero]   data keys: ", collect(keys(dat)))
-        println("[dispatchable-zero]   defaults: ", defaults)
-
         sol["is_dispatchable"] = 0
 
         if haskey(dat, "status")
             sol["status"] = dat["status"]
-            println("[dispatchable-zero]   set status=", dat["status"])
         end
 
         for (sol_var, data_field) in defaults
             if haskey(dat, data_field)
                 sol[sol_var] = dat[data_field]
-                println(
-                    "[dispatchable-zero]   set ",
-                    sol_var,
-                    " = ",
-                    dat[data_field],
-                    " from ",
-                    data_field,
-                )
             else
-                println(
+                @_info(
                     "[dispatchable-zero]   MISSING required data field ",
                     data_field,
                     " for ",
@@ -259,6 +238,6 @@ function _backfill_is_dispatchable_zero_components!(
             end
         end
 
-        println("[dispatchable-zero]   final sol entry: ", sol)
+        @_info("[dispatchable-zero]   final sol entry: ", sol)
     end
 end

--- a/src/core/solution.jl
+++ b/src/core/solution.jl
@@ -122,23 +122,29 @@ function sol_regulator_p_to_r!(gm::AbstractGasModel, solution::Dict)
     end
 end
 
-const _IS_DISPATCHABLE_ZERO_DEFAULTS = Dict(
+const IS_DISPATCHABLE_ZERO_DEFAULTS = Dict(
     :receipt => Dict("fg" => "injection_nominal"),
     :delivery => Dict("fd" => "withdrawal_nominal"),
     :transfer => Dict("ft" => "withdrawal_nominal"),
 )
 
 function sol_is_dispatchable_zero_components!(gm::AbstractGasModel, solution::Dict)
+    println("[dispatchable-zero] entered processor")
+
     if haskey(solution["it"][gm_it_name], "nw")
         nws_sol = solution["it"][gm_it_name]["nw"]
+        println("[dispatchable-zero] solution is multinetwork with networks: ", collect(keys(nws_sol)))
     else
         nws_sol = Dict("0" => solution["it"][gm_it_name])
+        println("[dispatchable-zero] solution is single network")
     end
 
     nws_data =
         if get(gm.data, "multinetwork", false)
+            println("[dispatchable-zero] gm.data is multinetwork with networks: ", collect(keys(gm.data["nw"])))
             gm.data["nw"]
         else
+            println("[dispatchable-zero] gm.data is single network")
             Dict("0" => gm.data)
         end
 
@@ -146,7 +152,12 @@ function sol_is_dispatchable_zero_components!(gm::AbstractGasModel, solution::Di
         n = parse(Int, n_str)
         nw_data = nws_data[n_str]
 
-        for (comp_name, defaults) in _IS_DISPATCHABLE_ZERO_DEFAULTS
+        println("[dispatchable-zero] processing network ", n_str)
+        println("[dispatchable-zero] nw_sol component keys: ", collect(keys(nw_sol)))
+        println("[dispatchable-zero] nw_data component keys: ", collect(keys(nw_data)))
+
+        for (comp_name, defaults) in IS_DISPATCHABLE_ZERO_DEFAULTS
+            println("[dispatchable-zero] checking component type: ", comp_name)
             _backfill_is_dispatchable_zero_components!(
                 gm,
                 n,
@@ -157,6 +168,8 @@ function sol_is_dispatchable_zero_components!(gm::AbstractGasModel, solution::Di
             )
         end
     end
+
+    println("[dispatchable-zero] finished processor")
 end
 
 function _is_dispatchable_zero_missing_ids(
@@ -175,14 +188,12 @@ function _is_dispatchable_zero_missing_ids(
     data_comps = nw_data[comp_key]
     sol_comps = get(nw_sol, comp_key, Dict{String,Any}())
 
-    ref_ids = Set(ids(gm, n, comp_name))
     out = Int[]
 
     for (k, data_comp) in data_comps
         i = parse(Int, k)
 
         if get(data_comp, "is_dispatchable", 1) == 0 &&
-           !(i in ref_ids) &&
            !haskey(sol_comps, k)
             push!(out, i)
         end
@@ -190,7 +201,6 @@ function _is_dispatchable_zero_missing_ids(
 
     return out
 end
-
 function _backfill_is_dispatchable_zero_components!(
     gm::AbstractGasModel,
     n::Int,
@@ -200,7 +210,11 @@ function _backfill_is_dispatchable_zero_components!(
     defaults::Dict{String,String},
 )
     ids0 = _is_dispatchable_zero_missing_ids(gm, n, nw_data, nw_sol, comp_name)
-    isempty(ids0) && return
+
+    if isempty(ids0)
+        println("[dispatchable-zero] no components to backfill for ", comp_name, " on network ", n)
+        return
+    end
 
     comp_key = string(comp_name)
     data_comps = nw_data[comp_key]
@@ -211,20 +225,40 @@ function _backfill_is_dispatchable_zero_components!(
         dat = data_comps[k]
         sol = get!(sol_comps, k, Dict{String,Any}())
 
+        println("[dispatchable-zero] backfilling ", comp_key, " ", k)
+        println("[dispatchable-zero]   data keys: ", collect(keys(dat)))
+        println("[dispatchable-zero]   defaults: ", defaults)
+
         sol["is_dispatchable"] = 0
 
         if haskey(dat, "status")
             sol["status"] = dat["status"]
+            println("[dispatchable-zero]   set status=", dat["status"])
         end
 
         for (sol_var, data_field) in defaults
             if haskey(dat, data_field)
                 sol[sol_var] = dat[data_field]
+                println(
+                    "[dispatchable-zero]   set ",
+                    sol_var,
+                    " = ",
+                    dat[data_field],
+                    " from ",
+                    data_field,
+                )
             else
-                @_warn(
-                    "Cannot backfill non-dispatchable $(comp_key) $(k): missing field `$(data_field)`"
+                println(
+                    "[dispatchable-zero]   MISSING required data field ",
+                    data_field,
+                    " for ",
+                    comp_key,
+                    " ",
+                    k,
                 )
             end
         end
+
+        println("[dispatchable-zero]   final sol entry: ", sol)
     end
 end

--- a/test/ogf.jl
+++ b/test/ogf.jl
@@ -18,6 +18,28 @@
             @test res["termination_status"] in [LOCALLY_SOLVED, OPTIMAL]
             @test isapprox(res["objective"], -167.19, rtol=1e-2)
         end
+        
+        @testset "test is_dispatchable zero components in solution" begin
+            data = GasModels.parse_file("../test/data/matgas/case-6.m")
+
+            data["receipt"]["1"]["is_dispatchable"] = 0
+
+            res = run_model(
+                data,
+                WPGasModel,
+                nlp_solver,
+                build_ogf;
+                solution_processors = [
+                    sol_psqr_to_p!,
+                    sol_compressor_p_to_r!,
+                    sol_regulator_p_to_r!,
+                    sol_is_dispatchable_zero_components!,
+                ],
+            )
+
+            @test res["primal_status"] in [MathOptInterface.FEASIBLE_POINT]
+            @test haskey(res["solution"]["receipt"], "1")
+        end
 
         @testset "case 6 ogf" begin
             @_info "Testing OGF"

--- a/test/ogf.jl
+++ b/test/ogf.jl
@@ -22,7 +22,7 @@
         @testset "test is_dispatchable zero components in solution" begin
             data = GasModels.parse_file("../test/data/matgas/case-6.m")
 
-            data["receipt"]["1"]["is_dispatchable"] = 0
+            data["transfer"]["1"]["is_dispatchable"] = 0
 
             res = run_model(
                 data,
@@ -38,7 +38,7 @@
             )
 
             @test res["primal_status"] in [MathOptInterface.FEASIBLE_POINT]
-            @test haskey(res["solution"]["receipt"], "1")
+            @test haskey(res["solution"]["transfer"], "1")
         end
 
         @testset "case 6 ogf" begin


### PR DESCRIPTION
adds a solution postprocessor very similar to the status = 0 one. this is not included in solve ogf, and can be manually added to the solution processors list in `run_model`. 

closes #301 