### PR TITLE
Make temperature per-pipe

### DIFF
--- a/src/core/transient_expression.jl
+++ b/src/core/transient_expression.jl
@@ -150,15 +150,37 @@ function expression_non_slack_affine_derivative(
     end
 end
 
+function _get_compressor_pipe(ref_pipe, compressor)
+    fr = compressor[:fr_junction]
+    to = compressor[:to_junction]
+
+    for (_, pipe) in ref_pipe
+        if pipe[:fr_junction] == fr && pipe[:to_junction] == to
+            return pipe
+        end
+    end
+
+    @_error("No pipe found for compressor from junction $fr to junction $to")
+end
+
 "compression power"
 function expression_compressor_power(gm::AbstractGasModel, nw::Int; report::Bool = false)
     comp_power = var(gm, nw)[:compressor_power_expr] = Dict{Int,Any}()
+
     for (i, compressor) in ref(gm, nw, :compressor)
         alpha = var(gm, nw, :compressor_ratio, i)
         f = var(gm, nw, :compressor_flow, i)
-        m = (gm.ref[:it][gm_it_sym][:specific_heat_capacity_ratio] - 1) /
-            gm.ref[:it][gm_it_sym][:specific_heat_capacity_ratio]
-        W = 286.76 * gm.ref[:it][gm_it_sym][:temperature] / gm.ref[:it][gm_it_sym][:gas_specific_gravity] / m
-        var(gm, nw, :compressor_power_expr)[i] = JuMP.@expression(gm.model, W * abs(f) * (alpha^m - 1.0))
+
+        gamma = gm.ref[:it][gm_it_sym][:specific_heat_capacity_ratio]
+        m = (gamma - 1) / gamma
+
+        pipe = ref(gm, nw, :pipe, i)
+        if !haskey(pipe, :temperature)
+            @_error("temperature missing from pipe $i while building compressor power expression")
+        end
+
+        W = 286.76 * pipe[:temperature] / gm.ref[:it][gm_it_sym][:gas_specific_gravity] / m
+
+        comp_power[i] = JuMP.@expression(gm.model, W * abs(f) * (alpha^m - 1.0))
     end
 end

--- a/src/core/transient_expression.jl
+++ b/src/core/transient_expression.jl
@@ -175,11 +175,12 @@ function expression_compressor_power(gm::AbstractGasModel, nw::Int; report::Bool
         m = (gamma - 1) / gamma
 
         pipe = ref(gm, nw, :pipe, i)
-        if !haskey(pipe, :temperature)
+        # @show pipe
+        if !haskey(pipe, "temperature")
             @_error("temperature missing from pipe $i while building compressor power expression")
         end
 
-        W = 286.76 * pipe[:temperature] / gm.ref[:it][gm_it_sym][:gas_specific_gravity] / m
+        W = 286.76 * pipe["temperature"] / gm.ref[:it][gm_it_sym][:gas_specific_gravity] / m
 
         comp_power[i] = JuMP.@expression(gm.model, W * abs(f) * (alpha^m - 1.0))
     end

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -96,6 +96,34 @@ function check_soundspeed!(mn_data::Dict{String,Any}; tol=0.5)
     return nothing
 end
 
+"""
+    _move_global_temperature_to_pipes!(data::Dict{String,Any})
+
+Temporary migration helper.
+
+Copies the global `data["temperature"]` value into every pipe dictionary as
+`pipe["temperature"]`, then removes `data["temperature"]`.
+
+Operates in-place on the base data dictionary returned by `parse_file`.
+"""
+function _move_global_temperature_to_pipes!(data::Dict{String,Any})
+    if !haskey(data, "temperature")
+        return data
+    end
+
+    temperature = data["temperature"]
+
+    if haskey(data, "pipe")
+        for (_, pipe) in data["pipe"]
+            pipe["temperature"] = temperature
+        end
+    end
+
+    delete!(data, "temperature")
+
+    return data
+end
+
 function correct_network_data!(data::Dict{String,Any}, slack_nodes::Bool = false)
     check_non_negativity(data)
     check_pipeline_geometry!(data) #geo must be checked before per-unit conversion
@@ -120,6 +148,7 @@ function correct_network_data!(data::Dict{String,Any}, slack_nodes::Bool = false
     check_status(data)
     check_edge_loops(data)
     check_global_parameters(data)
+    _move_global_temperature_to_pipes!(data)
     if slack_nodes
         correct_slack_nodes!(data)
     end

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -135,7 +135,7 @@ function correct_network_data!(data::Dict{String,Any}, slack_nodes::Bool = false
     add_compressor_fields!(data)
 
     make_si_units!(data)
-    check_soundspeed!(data)
+    # check_soundspeed!(data)
     # select_largest_component!(data)
     propagate_topology_status!(data)
     add_base_values!(data)

--- a/src/io/transient.jl
+++ b/src/io/transient.jl
@@ -59,6 +59,7 @@ function parse_files(
     static_data = parse_file(static_io) 
     make_si_units!(static_data)
     prep_transient_data!(static_data; spatial_discretization=spatial_discretization)
+    _move_global_temperature_to_pipes!(static_data)
 
     # --- Read and convert transient data ---
     transient_data = parse_transient(transient_io)
@@ -80,9 +81,18 @@ function parse_files(
     )
 
     mn_data = _IM.make_multinetwork(static_data, gm_it_name, _gm_global_keys)
+    # for (i, pipe) in static_data["pipe"]
+    #     @assert haskey(pipe, "temperature") "temperature missing from static_data[\"pipe\"][$i]"
+    # end
+    @assert !haskey(static_data, "temperature")
 
     # --- Final per-unit conversion --- 
     make_per_unit!(mn_data)
+    # for (i, pipe) in static_data["pipe"]
+    #     @assert haskey(pipe, "temperature") "temperature missing from static_data[\"pipe\"][$i]"
+    # end
+    @assert !haskey(static_data, "temperature")
+
 
     return mn_data
 end
@@ -256,7 +266,8 @@ function _prep_transient_data!(
                 "english_units",
                 "per_unit",
                 "flow_min", 
-                "flow_max"
+                "flow_max",
+                "temperature"
             ]
 
             data["pipe"][key] = Dict{String,Any}()
@@ -336,7 +347,8 @@ function _prep_transient_data!(
                 "english_units" => data["english_units"],
                 "per_unit" => data["per_unit"],
                 "flow_min" => pipe["flow_min"],
-                "flow_max" => pipe["flow_max"]
+                "flow_max" => pipe["flow_max"],
+                "temperature" => pipe["temperature"],
             )
         end
     end
@@ -357,7 +369,7 @@ function _create_time_series_block(
     end_time = total_time + additional_time
 
     if (time_step > 3600.0 && time_step % 3600.0 != 0.0)
-        error(
+        @_error(
             "the 3600 seconds has to be exactly divisible by the time step,
 provide a time step that exactly divides 3600.0",
         )


### PR DESCRIPTION
Would like some feedback from @rb004f and/or @kaarthiksundar here:

I added a function to move temperature into the data dict for each pipe, which interestingly does not affect `solve_ogf` at all. All static ogf tests are unchanged and they pass. 

The same cannot be said for the transient ogf. I changed the discretization function to copy the per-pipe temp into each new pipe, but there is still a key error happening somewhere. Significant changes were required for the compressor power expression, but I _think_ those were fixed and the error is from something else. See below:

```
julia> res = solve_transient_ogf(case, WPGasModel, build_ipopt_solver())
ERROR: KeyError: key 2 not found
Stacktrace:
  [1] getindex(h::Dict{Int64, Any}, key::Int64)
    @ Base .\dict.jl:477
  [2] ref(aim::WPGasModel, it::Symbol, nw::Int64, key::Symbol, idx::Int64)
    @ InfrastructureModels U:\InfrastructureModels.jl\src\core\base.jl:278
  [3] ref(gm::WPGasModel, nw::Int64, key::Symbol, idx::Int64)
    @ GasModels U:\dev\GasModels.jl\src\core\base.jl:298
  [4] expression_compressor_power(gm::WPGasModel, nw::Int64; report::Bool)
    @ GasModels U:\dev\GasModels.jl\src\core\transient_expression.jl:177
  [5] expression_compressor_power
    @ U:\dev\GasModels.jl\src\core\transient_expression.jl:167 [inlined]
  [6] build_transient_ogf(gm::WPGasModel)
    @ GasModels U:\dev\GasModels.jl\src\prob\transient_ogf.jl:60
  [7] instantiate_model(data::Dict{…}, model_type::Type, build_method::typeof(build_transient_ogf), ref_add_core!::typeof(ref_add_core!), global_keys::Set{…}, it::Symbol; ref_extensions::Vector{…}, kwargs::@Kwargs{…})
    @ InfrastructureModels U:\InfrastructureModels.jl\src\core\base.jl:370
  [8] instantiate_model
    @ U:\InfrastructureModels.jl\src\core\base.jl:350 [inlined]
  [9] #instantiate_model#266
    @ U:\dev\GasModels.jl\src\core\base.jl:48 [inlined]
 [10] instantiate_model
    @ U:\dev\GasModels.jl\src\core\base.jl:47 [inlined]
 [11] run_model(data::Dict{…}, model_type::Type, optimizer::MathOptInterface.OptimizerWithAttributes, build_method::typeof(build_transient_ogf); ref_extensions::Vector{…}, solution_processors::Vector{…}, relax_integrality::Bool, kwargs::@Kwargs{})
    @ GasModels U:\dev\GasModels.jl\src\core\base.jl:18
 [12] run_model
    @ U:\dev\GasModels.jl\src\core\base.jl:17 [inlined]
 [13] solve_transient_ogf(data::Dict{String, Any}, model_type::Type, optimizer::MathOptInterface.OptimizerWithAttributes; kwargs::@Kwargs{})
    @ GasModels U:\dev\GasModels.jl\src\prob\transient_ogf.jl:6
 [14] solve_transient_ogf(data::Dict{String, Any}, model_type::Type, optimizer::MathOptInterface.OptimizerWithAttributes)
    @ GasModels U:\dev\GasModels.jl\src\prob\transient_ogf.jl:2
 [15] top-level scope
    @ REPL[4]:1
Some type information was truncated. Use `show(err)` to see complete types.

julia>
```

Is there some extra information that `solve_transient_ogf` needs?