### PR TITLE
patch to broken variable function

### DIFF
--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -321,13 +321,14 @@ function variable_load_mass_flow(gm::AbstractGasModel, nw::Int=nw_id_default; bo
 end
 
 
-"variables associated with transfer"
-function variable_transfer_mass_flow(gm::AbstractGasModel, nw::Int=nw_id_default; bounded::Bool=true, report::Bool=true, is_nominal::Bool=false)
-    flow_start(transfer) = is_nominal ? transfer["withdrawal_nominal"] :
-        (transfer["withdrawal_min"] < 0.0 ? transfer["withdrawal_min"] : transfer["withdrawal_max"])
+# "variables associated with transfer"
+# function variable_transfer_mass_flow(gm::AbstractGasModel, nw::Int=nw_id_default; bounded::Bool=true, report::Bool=true, is_nominal::Bool=false)
+#     flow_start(transfer) = is_nominal ? transfer["withdrawal_nominal"] :
+#         (transfer["withdrawal_min"] < 0.0 ? transfer["withdrawal_min"] : transfer["withdrawal_max"])
 
-    flow_bounds(transfer) = is_nominal ? minmax(0.0, transfer["withdrawal_nominal"]) :
-        (transfer["withdrawal_min"], transfer["withdrawal_max"])
+#     flow_bounds(transfer) = is_nominal ? minmax(0.0, transfer["withdrawal_nominal"]) :
+#         (transfer["withdrawal_min"], transfer["withdrawal_max"])
+
 function variable_transfer_mass_flow(gm::AbstractGasModel, nw::Int=nw_id_default; bounded::Bool=true, report::Bool=true)
     flow_start(transfer)  =  transfer["withdrawal_min"] < 0.0 ? transfer["withdrawal_min"] : transfer["withdrawal_max"]
     flow_bounds(transfer) = (transfer["withdrawal_min"], transfer["withdrawal_max"])


### PR DESCRIPTION
a new function introduced in a recent commit was missing an end statement, which blew up the precompile process. 

that function also caused a method override during precompile, which is not allowed by the Julia compiler. It appears to me that this function was not finished and was merged to master by accident, so it has been temporarily removed. 