### PR TITLE
prep for version 0.13.3 bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## staged 
 - nothing
 
+## v0.13.3
+- Bug Fix: corrects unit conversion in `parse_separated_data` and the upstream function `apply_nominations`. The previous code, described in Issue #344, incorrectly applied a per-unit conversion to price data. 
+
 ## v0.13.2
 - Add: ability to include deactivated (status=0) components in the solution dictionary. This is a solution processor that must be manually added to the processors list in `run_model`, and is not user-facing in `solve_ogf`. 
 

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "GasModels"
 uuid = "5e113713-6c35-5477-b766-e1109486666f"
 authors = ["Russell Bent <rbent@lanl.gov>", "Kaarthik Sundar <kaarthik@lanl.gov>", "David Fobes <dfobes@lanl.gov>"]
 repo = "https://github.com/lanl-ansi/GasModels.jl.git"
-version = "0.13.2"
+version = "0.13.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
bug fix for price code- doing a version bump so that the official julia repo has the correct code