### PR TITLE
Transfer offer_price sign correction

### DIFF
--- a/src/core/objective.jl
+++ b/src/core/objective.jl
@@ -73,7 +73,7 @@ end
     \\sum_{ijk \\in {\\cal C}} \\boldsymbol{f}_{ijk} (\\boldsymbol{\\alpha}_{ijk}^m - 1)``"
 function objective_min_economic_costs(gm::AbstractGasModel, nws = [nw_id_default])
     transfer_price(transfer) = transfer["withdrawal_min"] >= 0.0 ?
-        get(transfer, "bid_price", 1.0) : (-1) * get(transfer, "offer_price", 1.0)
+        get(transfer, "bid_price", 1.0) : (1) * get(transfer, "offer_price", 1.0)
 
     r = Dict(n => var(gm, n, :rsqr) for n in nws)
     f = Dict(n => var(gm, n, :f_compressor) for n in nws)

--- a/test/mnw.jl
+++ b/test/mnw.jl
@@ -1,6 +1,14 @@
 solution_file = "../test/data/transient/case6_ls_a_solution.json"
 elevation_solution_file = "../test/data/transient/case6elevationtr.json"
 
+# Ipopt solver without barrier initialization for sequential steady-state solves
+ipopt_no_barrier = JuMP.optimizer_with_attributes(
+    Ipopt.Optimizer,
+    "print_level" => 0,
+    "sb" => "yes",
+    "acceptable_tol" => 1.0e-4,
+)
+
 @testset "confirm that changes occur in parse_multinetwork" begin
     mn_data = parse_multinetwork("../test/data/matgas/case-6.m", "../test/data/transient/time-series-case-6a.csv", time_step=864.0)
     @test (mn_data["nw"]["1"]["transfer"]["1"]["withdrawal_max"] !== mn_data["nw"]["100"]["transfer"]["1"]["withdrawal_max"])
@@ -82,7 +90,7 @@ end
  
     for nw in keys(mn_data["nw"])
         settings = Dict("config" => Dict("networks" => [parse(Int,nw)]))
-        solution = GasModels.solve_ogf(mn_data, WPGasModel, nlp_solver, setting=settings)
+        solution = GasModels.solve_ogf(mn_data, WPGasModel, ipopt_no_barrier, setting=settings)
         @test solution["termination_status"] == LOCALLY_SOLVED
         result["solution"]["nw"][nw] = solution["solution"]["nw"][nw]
 

--- a/test/ogf_nominal.jl
+++ b/test/ogf_nominal.jl
@@ -36,12 +36,12 @@
             @_info "Testing OGF Nominal Modified transfer"
             data = GasModels.parse_file("../test/data/matgas/case-6-no-power-limits-nominal.m")
             transfer = data["transfer"]["1"]
-            transfer["withdrawal_nominal"] = - transfer["withdrawal_max"] / 2.0
-
+            transfer["withdrawal_nominal"] = transfer["withdrawal_max"] / 2.0
+            ref = build_ref(data)
             result = solve_ogf_nominal(data, WPGasModel, nlp_solver)
             GasModels.make_si_units!(result["solution"])
             @test result["termination_status"] in [LOCALLY_SOLVED, ALMOST_LOCALLY_SOLVED, OPTIMAL, :Suboptimal]
-            @test isapprox(result["solution"]["transfer"]["1"]["ft"], -15.0; atol = 1e-2)
+            @test isapprox(result["solution"]["transfer"]["1"]["ft"], 15.0; atol = 1e-2)
         end
 
         @testset "case 6 ogf nominal" begin


### PR DESCRIPTION
Correcting the treatment of offer_price in transfers, which is currently flipped in objective_min_economic_costs.

Correcting ogf_nominal test so that withdrawal_nominal and withdrawal_max have the same sign.